### PR TITLE
feat: Add Radio field component

### DIFF
--- a/packages/core/src/forms/fields.test.ts
+++ b/packages/core/src/forms/fields.test.ts
@@ -8,6 +8,7 @@ import {
   Select,
   Checkbox,
   Switch,
+  Radio,
 } from './fields'
 
 describe('Field Builders', () => {
@@ -306,6 +307,103 @@ describe('Field Builders', () => {
 
       expect(field1.label).toBe('User Name')
       expect(field2.label).toBe('User Name')
+    })
+  })
+
+  describe('Radio', () => {
+    it('should create radio field', () => {
+      const field = Radio.make('status')
+        .label('Status')
+        .options([
+          { label: 'Active', value: 'active' },
+          { label: 'Inactive', value: 'inactive' },
+        ])
+        .build()
+
+      expect(field.type).toBe('radio')
+      expect(field.name).toBe('status')
+      expect(field.label).toBe('Status')
+      expect(field.options).toHaveLength(2)
+    })
+
+    it('should set inline layout', () => {
+      const field = Radio.make('status')
+        .options([
+          { label: 'Yes', value: 'yes' },
+          { label: 'No', value: 'no' },
+        ])
+        .inline()
+        .build()
+
+      expect(field.inline).toBe(true)
+    })
+
+    it('should set required', () => {
+      const field = Radio.make('status')
+        .options([{ label: 'Option 1', value: '1' }])
+        .required()
+        .build()
+
+      expect(field.required).toBe(true)
+    })
+
+    it('should set disabled', () => {
+      const field = Radio.make('status')
+        .options([{ label: 'Option 1', value: '1' }])
+        .disabled(true)
+        .build()
+
+      expect(field.disabled).toBe(true)
+    })
+
+    it('should set conditional disabled', () => {
+      const condition = (values: Record<string, unknown>) => values.locked === true
+      const field = Radio.make('status')
+        .options([{ label: 'Option 1', value: '1' }])
+        .disabled(condition)
+        .build()
+
+      expect(field.disabled).toBe(condition)
+    })
+
+    it('should set helper text', () => {
+      const field = Radio.make('status')
+        .options([{ label: 'Option 1', value: '1' }])
+        .helperText('Select one option')
+        .build()
+
+      expect(field.helperText).toBe('Select one option')
+    })
+
+    it('should set default value', () => {
+      const field = Radio.make('status')
+        .options([
+          { label: 'Active', value: 'active' },
+          { label: 'Inactive', value: 'inactive' },
+        ])
+        .default('active')
+        .build()
+
+      expect(field.default).toBe('active')
+    })
+
+    it('should throw error if name is missing', () => {
+      const builder = Radio.make('')
+        .options([{ label: 'Option 1', value: '1' }])
+
+      expect(() => builder.build()).toThrow('Field name is required')
+    })
+
+    it('should throw error if options are empty', () => {
+      const builder = Radio.make('status')
+
+      expect(() => builder.build()).toThrow('Radio field must have at least one option')
+    })
+
+    it('should throw error if options array is empty', () => {
+      const builder = Radio.make('status').options([])
+
+      expect(() => builder.build()).toThrow('Radio field must have at least one option')
     })
   })
 })

--- a/packages/core/src/forms/fields.tsx
+++ b/packages/core/src/forms/fields.tsx
@@ -335,6 +335,76 @@ export class SwitchBuilder extends CheckboxBuilder {
 }
 
 /**
+ * Radio field builder
+ */
+export class RadioBuilder {
+  private config: Partial<RadioFieldConfig> = {
+    type: 'radio',
+    name: '',
+    options: [],
+  }
+
+  constructor(name: string) {
+    this.config.name = name
+  }
+
+  label(label: string): this {
+    this.config.label = label
+    return this
+  }
+
+  options(options: SelectOption[]): this {
+    this.config.options = options
+    return this
+  }
+
+  inline(inline = true): this {
+    this.config.inline = inline
+    return this
+  }
+
+  required(required = true): this {
+    this.config.required = required
+    return this
+  }
+
+  disabled(disabled: boolean | ((values: Record<string, unknown>) => boolean)): this {
+    this.config.disabled = disabled
+    return this
+  }
+
+  visible(visible: boolean | ((values: Record<string, unknown>) => boolean)): this {
+    this.config.visible = visible
+    return this
+  }
+
+  helperText(text: string): this {
+    this.config.helperText = text
+    return this
+  }
+
+  default(value: unknown): this {
+    this.config.default = value
+    return this
+  }
+
+  columnSpan(span: number): this {
+    this.config.columnSpan = span
+    return this
+  }
+
+  build(): RadioFieldConfig {
+    if (!this.config.name) {
+      throw new Error('Field name is required')
+    }
+    if (!this.config.options || this.config.options.length === 0) {
+      throw new Error('Radio field must have at least one option')
+    }
+    return this.config as RadioFieldConfig
+  }
+}
+
+/**
  * Factory functions for creating field builders
  */
 export const TextInput = {
@@ -367,4 +437,8 @@ export const Checkbox = {
 
 export const Switch = {
   make: (name: string, label: string) => new SwitchBuilder(name, label),
+}
+
+export const Radio = {
+  make: (name: string) => new RadioBuilder(name),
 }


### PR DESCRIPTION
Add Radio field builder with fluent API supporting:
- Radio options configuration
- Inline/stacked layout
- Required validation
- Conditional disabled/visible state
- Helper text
- Default value
- Column span

Tests: 10 new tests added, all 637 tests passing