### PR TITLE
feat: Add form layout components (Story 3.5)

### DIFF
--- a/packages/core/src/forms/FormCard.tsx
+++ b/packages/core/src/forms/FormCard.tsx
@@ -1,0 +1,75 @@
+/**
+ * FormCard Component
+ * Card/panel wrapper for form sections with visual grouping
+ */
+
+import type { ReactNode } from 'react'
+
+/**
+ * Form card props
+ */
+export interface FormCardProps {
+  /** Card title */
+  title?: string
+
+  /** Card description */
+  description?: string
+
+  /** Card children */
+  children: ReactNode
+
+  /** Custom className */
+  className?: string
+
+  /** Whether to show border */
+  bordered?: boolean
+
+  /** Whether to show shadow */
+  shadow?: boolean
+
+  /** Padding size */
+  padding?: 'none' | 'sm' | 'md' | 'lg'
+}
+
+/**
+ * FormCard Component
+ */
+export function FormCard({
+  title,
+  description,
+  children,
+  className = '',
+  bordered = true,
+  shadow = false,
+  padding = 'md',
+}: FormCardProps) {
+  const paddingClasses = {
+    none: '',
+    sm: 'p-4',
+    md: 'p-6',
+    lg: 'p-8',
+  }
+
+  return (
+    <div
+      className={`
+        bg-white rounded-lg
+        ${bordered ? 'border border-gray-200' : ''}
+        ${shadow ? 'shadow-sm' : ''}
+        ${paddingClasses[padding]}
+        ${className}
+      `}
+    >
+      {(title || description) && (
+        <div className="mb-6">
+          {title && <h3 className="text-lg font-medium text-gray-900">{title}</h3>}
+          {description && (
+            <p className="mt-1 text-sm text-gray-500">{description}</p>
+          )}
+        </div>
+      )}
+
+      <div className="space-y-6">{children}</div>
+    </div>
+  )
+}

--- a/packages/core/src/forms/FormGrid.tsx
+++ b/packages/core/src/forms/FormGrid.tsx
@@ -1,0 +1,50 @@
+/**
+ * FormGrid Component
+ * Grid layout for form fields with responsive columns
+ */
+
+import type { ReactNode } from 'react'
+
+/**
+ * Form grid props
+ */
+export interface FormGridProps {
+  /** Grid children */
+  children: ReactNode
+
+  /** Number of columns (1-12) */
+  columns?: 1 | 2 | 3 | 4 | 6 | 12
+
+  /** Gap between columns */
+  gap?: number
+
+  /** Custom className */
+  className?: string
+}
+
+/**
+ * FormGrid Component
+ */
+export function FormGrid({
+  children,
+  columns = 2,
+  gap = 6,
+  className = '',
+}: FormGridProps) {
+  const gridCols = {
+    1: 'grid-cols-1',
+    2: 'grid-cols-1 md:grid-cols-2',
+    3: 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3',
+    4: 'grid-cols-1 md:grid-cols-2 lg:grid-cols-4',
+    6: 'grid-cols-1 md:grid-cols-3 lg:grid-cols-6',
+    12: 'grid-cols-12',
+  }
+
+  const gapClass = `gap-${gap}`
+
+  return (
+    <div className={`grid ${gridCols[columns]} ${gapClass} ${className}`}>
+      {children}
+    </div>
+  )
+}

--- a/packages/core/src/forms/FormSection.tsx
+++ b/packages/core/src/forms/FormSection.tsx
@@ -1,0 +1,86 @@
+/**
+ * FormSection Component
+ * Displays a section with title and description
+ */
+
+import { useState } from 'react'
+import type { ReactNode } from 'react'
+
+/**
+ * Form section props
+ */
+export interface FormSectionProps {
+  /** Section title */
+  title?: string
+
+  /** Section description */
+  description?: string
+
+  /** Section children */
+  children: ReactNode
+
+  /** Custom className */
+  className?: string
+
+  /** Whether section is collapsible */
+  collapsible?: boolean
+
+  /** Initially collapsed state (only if collapsible) */
+  defaultCollapsed?: boolean
+}
+
+/**
+ * FormSection Component
+ */
+export function FormSection({
+  title,
+  description,
+  children,
+  className = '',
+  collapsible = false,
+  defaultCollapsed = false,
+}: FormSectionProps) {
+  const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed)
+
+  const toggleCollapse = () => {
+    if (collapsible) {
+      setIsCollapsed(!isCollapsed)
+    }
+  }
+
+  return (
+    <div className={`space-y-4 ${className}`}>
+      {(title || description) && (
+        <div className="border-b border-gray-200 pb-4">
+          {title && (
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-medium text-gray-900">{title}</h3>
+              {collapsible && (
+                <button
+                  type="button"
+                  onClick={toggleCollapse}
+                  className="text-gray-500 hover:text-gray-700"
+                  aria-label={isCollapsed ? 'Expand section' : 'Collapse section'}
+                >
+                  <svg
+                    className={`w-5 h-5 transition-transform ${isCollapsed ? 'rotate-180' : ''}`}
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                  </svg>
+                </button>
+              )}
+            </div>
+          )}
+          {description && !isCollapsed && (
+            <p className="mt-1 text-sm text-gray-500">{description}</p>
+          )}
+        </div>
+      )}
+
+      {!isCollapsed && <div className="space-y-6">{children}</div>}
+    </div>
+  )
+}

--- a/packages/core/src/forms/index.ts
+++ b/packages/core/src/forms/index.ts
@@ -5,3 +5,6 @@
 
 export * from './builder'
 export * from './fields'
+export * from './FormSection'
+export * from './FormGrid'
+export * from './FormCard'

--- a/packages/core/src/forms/layouts.test.tsx
+++ b/packages/core/src/forms/layouts.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * Form Layout Components Tests
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FormSection } from './FormSection'
+import { FormGrid } from './FormGrid'
+import { FormCard } from './FormCard'
+
+describe('Form Layout Components', () => {
+  describe('FormSection', () => {
+    it('should render title and description', () => {
+      render(
+        <FormSection title="Personal Information" description="Enter your personal details">
+          <div>Content</div>
+        </FormSection>
+      )
+
+      expect(screen.getByText('Personal Information')).toBeInTheDocument()
+      expect(screen.getByText('Enter your personal details')).toBeInTheDocument()
+      expect(screen.getByText('Content')).toBeInTheDocument()
+    })
+
+    it('should render children without title', () => {
+      render(
+        <FormSection>
+          <div>Content</div>
+        </FormSection>
+      )
+
+      expect(screen.getByText('Content')).toBeInTheDocument()
+    })
+
+    it('should be collapsible', async () => {
+      const user = userEvent.setup()
+      render(
+        <FormSection title="Section" collapsible defaultCollapsed={false}>
+          <div>Content</div>
+        </FormSection>
+      )
+
+      expect(screen.getByText('Content')).toBeInTheDocument()
+
+      const collapseButton = screen.getByLabelText('Collapse section')
+      await user.click(collapseButton)
+
+      expect(screen.queryByText('Content')).not.toBeInTheDocument()
+    })
+
+    it('should start collapsed when defaultCollapsed is true', () => {
+      render(
+        <FormSection title="Section" collapsible defaultCollapsed>
+          <div>Content</div>
+        </FormSection>
+      )
+
+      expect(screen.queryByText('Content')).not.toBeInTheDocument()
+    })
+
+    it('should not show collapse button when not collapsible', () => {
+      render(
+        <FormSection title="Section">
+          <div>Content</div>
+        </FormSection>
+      )
+
+      expect(screen.queryByLabelText('Collapse section')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('FormGrid', () => {
+    it('should render children in grid', () => {
+      render(
+        <FormGrid columns={2}>
+          <div>Field 1</div>
+          <div>Field 2</div>
+        </FormGrid>
+      )
+
+      expect(screen.getByText('Field 1')).toBeInTheDocument()
+      expect(screen.getByText('Field 2')).toBeInTheDocument()
+    })
+
+    it('should apply correct grid columns class', () => {
+      const { container } = render(
+        <FormGrid columns={3}>
+          <div>Content</div>
+        </FormGrid>
+      )
+
+      const grid = container.firstChild as HTMLElement
+      expect(grid.className).toContain('grid-cols-1')
+      expect(grid.className).toContain('md:grid-cols-2')
+      expect(grid.className).toContain('lg:grid-cols-3')
+    })
+
+    it('should apply custom className', () => {
+      const { container } = render(
+        <FormGrid className="custom-class">
+          <div>Content</div>
+        </FormGrid>
+      )
+
+      expect(container.firstChild).toHaveClass('custom-class')
+    })
+  })
+
+  describe('FormCard', () => {
+    it('should render title and description', () => {
+      render(
+        <FormCard title="Card Title" description="Card description">
+          <div>Content</div>
+        </FormCard>
+      )
+
+      expect(screen.getByText('Card Title')).toBeInTheDocument()
+      expect(screen.getByText('Card description')).toBeInTheDocument()
+      expect(screen.getByText('Content')).toBeInTheDocument()
+    })
+
+    it('should render children without title', () => {
+      render(
+        <FormCard>
+          <div>Content</div>
+        </FormCard>
+      )
+
+      expect(screen.getByText('Content')).toBeInTheDocument()
+    })
+
+    it('should apply border when bordered is true', () => {
+      const { container } = render(
+        <FormCard bordered>
+          <div>Content</div>
+        </FormCard>
+      )
+
+      expect(container.firstChild).toHaveClass('border')
+    })
+
+    it('should not apply border when bordered is false', () => {
+      const { container } = render(
+        <FormCard bordered={false}>
+          <div>Content</div>
+        </FormCard>
+      )
+
+      expect(container.firstChild).not.toHaveClass('border')
+    })
+
+    it('should apply shadow when shadow is true', () => {
+      const { container } = render(
+        <FormCard shadow>
+          <div>Content</div>
+        </FormCard>
+      )
+
+      expect(container.firstChild).toHaveClass('shadow-sm')
+    })
+
+    it('should apply correct padding class', () => {
+      const { container } = render(
+        <FormCard padding="lg">
+          <div>Content</div>
+        </FormCard>
+      )
+
+      expect(container.firstChild).toHaveClass('p-8')
+    })
+  })
+})


### PR DESCRIPTION
Add form layout components for organizing forms:
- FormSection: Section with title, description, collapsible support
- FormGrid: Responsive grid layout (1-12 columns)
- FormCard: Card/panel wrapper with border, shadow, padding options

Features:
- Responsive grid columns
- Collapsible sections
- Visual grouping with cards
- Flexible padding and styling options

Tests: 14 new tests added, all 641 tests passing