### PR TITLE
feat: Add action separator support (Story 5.4)

### DIFF
--- a/packages/core/src/actions/builders.test.tsx
+++ b/packages/core/src/actions/builders.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { ButtonAction, LinkAction, ActionGroup, BulkAction } from './builders'
+import { ButtonAction, LinkAction, ActionGroup, BulkAction, ActionSeparator } from './builders'
 
 describe('Action Builders', () => {
   describe('ButtonAction', () => {
@@ -430,6 +430,29 @@ describe('Action Builders', () => {
       expect(action.requiresConfirmation).toBe(true)
       expect(action.visible).toBe(true)
       expect(action.disabled).toBe(false)
+    })
+  })
+
+  describe('ActionSeparator', () => {
+    it('should create action separator', () => {
+      const separator = ActionSeparator.make('sep-1').build()
+
+      expect(separator.type).toBe('separator')
+      expect(separator.id).toBe('sep-1')
+    })
+
+    it('should generate id if not provided', () => {
+      const separator = ActionSeparator.make().build()
+
+      expect(separator.type).toBe('separator')
+      expect(separator.id).toMatch(/^separator-/)
+    })
+
+    it('should create multiple separators with unique ids', () => {
+      const sep1 = ActionSeparator.make().build()
+      const sep2 = ActionSeparator.make().build()
+
+      expect(sep1.id).not.toBe(sep2.id)
     })
   })
 })

--- a/packages/core/src/actions/builders.tsx
+++ b/packages/core/src/actions/builders.tsx
@@ -9,6 +9,7 @@ import type {
   ButtonActionConfig,
   LinkActionConfig,
   ActionGroupConfig,
+  ActionSeparatorConfig,
   BulkAction,
   ActionVariant,
   ActionSize,
@@ -276,4 +277,31 @@ export const BulkAction = {
     label: string,
     action: (selected: TModel[]) => void | Promise<void>
   ) => new BulkActionBuilder<TModel>(id, label, action),
+}
+
+/**
+ * Action separator builder
+ */
+let separatorCounter = 0
+
+export class ActionSeparatorBuilder {
+  private config: ActionSeparatorConfig
+
+  constructor(id: string) {
+    this.config = {
+      type: 'separator',
+      id,
+    }
+  }
+
+  build(): ActionSeparatorConfig {
+    return this.config
+  }
+}
+
+export const ActionSeparator = {
+  make: (id?: string) => {
+    const generatedId = id || `separator-${Date.now()}-${separatorCounter++}`
+    return new ActionSeparatorBuilder(generatedId)
+  },
 }

--- a/packages/core/src/tables/RowActionsDropdown.test.tsx
+++ b/packages/core/src/tables/RowActionsDropdown.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { RowActionsDropdown } from './RowActionsDropdown'
-import type { ButtonActionConfig } from '../types/action'
+import type { ButtonActionConfig, Action } from '../types/action'
 
 interface TestModel {
   id: number
@@ -373,6 +373,39 @@ describe('RowActionsDropdown', () => {
 
     await waitFor(() => {
       expect(screen.queryByRole('menuitem', { name: 'Edit' })).not.toBeInTheDocument()
+    })
+  })
+
+  it('should render action separator', async () => {
+    const user = userEvent.setup()
+    const actions: Action<TestModel>[] = [
+      {
+        id: 'edit',
+        type: 'button',
+        label: 'Edit',
+        onClick: vi.fn(),
+      },
+      {
+        type: 'separator',
+        id: 'sep-1',
+      },
+      {
+        id: 'delete',
+        type: 'button',
+        label: 'Delete',
+        onClick: vi.fn(),
+      },
+    ]
+
+    render(<RowActionsDropdown record={testRecord} actions={actions} />)
+
+    const button = screen.getByLabelText('Row actions')
+    await user.click(button)
+
+    await waitFor(() => {
+      const separator = screen.getByRole('separator')
+      expect(separator).toBeInTheDocument()
+      expect(separator).toHaveClass('border-t')
     })
   })
 })

--- a/packages/core/src/tables/RowActionsDropdown.tsx
+++ b/packages/core/src/tables/RowActionsDropdown.tsx
@@ -140,6 +140,17 @@ export function RowActionsDropdown<TModel extends BaseModel>({
             <div className="absolute right-0 z-20 mt-2 w-48 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
               <div className="py-1" role="menu">
                 {visibleActions.map((action) => {
+                  // Handle separator
+                  if (action.type === 'separator') {
+                    return (
+                      <div
+                        key={action.id}
+                        className="my-1 border-t border-gray-200"
+                        role="separator"
+                      />
+                    )
+                  }
+
                   const disabled = isActionDisabled(action)
                   const isLoading = executingAction === action.id
 

--- a/packages/core/src/types/action.ts
+++ b/packages/core/src/types/action.ts
@@ -142,6 +142,15 @@ export interface LinkActionConfig<TModel extends BaseModel = BaseModel> extends 
 }
 
 /**
+ * Action separator
+ */
+export interface ActionSeparatorConfig {
+  type: 'separator'
+  /** Separator identifier */
+  id: string
+}
+
+/**
  * Dropdown action group
  */
 export interface ActionGroupConfig<TModel extends BaseModel = BaseModel> {
@@ -168,6 +177,7 @@ export type Action<TModel extends BaseModel = BaseModel> =
   | ButtonActionConfig<TModel>
   | LinkActionConfig<TModel>
   | ActionGroupConfig<TModel>
+  | ActionSeparatorConfig
 
 /**
  * Bulk action configuration


### PR DESCRIPTION
Add ActionSeparator type and builder to allow visual separation between groups of actions in dropdown menus. Separators render as horizontal dividers in the RowActionsDropdown component.