### PR TITLE
feat: Add navigation support to notification actions (Story 7.2)

### DIFF
--- a/packages/core/src/notifications/NotificationProvider.test.tsx
+++ b/packages/core/src/notifications/NotificationProvider.test.tsx
@@ -347,4 +347,52 @@ describe('NotificationProvider', () => {
 
     expect(onDismiss).toHaveBeenCalled()
   })
+
+  it('should navigate when action has href', async () => {
+    vi.useRealTimers()
+    const user = userEvent.setup()
+    const originalLocation = window.location.href
+
+    const { result } = renderHook(() => useNotifications(), {
+      wrapper: ({ children }) => <NotificationProvider>{children}</NotificationProvider>,
+    })
+
+    act(() => {
+      result.current.success('Navigation notification', {
+        actions: [{ label: 'Go to page', href: '/test-page' }],
+      })
+    })
+
+    const actionLink = screen.getByText('Go to page')
+    expect(actionLink).toBeInTheDocument()
+    expect(actionLink.tagName).toBe('A')
+    expect(actionLink).toHaveAttribute('href', '/test-page')
+
+    vi.useFakeTimers()
+  })
+
+  it('should execute onClick and navigate when both are provided', async () => {
+    vi.useRealTimers()
+    const onClick = vi.fn()
+    const user = userEvent.setup()
+
+    const { result } = renderHook(() => useNotifications(), {
+      wrapper: ({ children }) => <NotificationProvider>{children}</NotificationProvider>,
+    })
+
+    act(() => {
+      result.current.success('Combined action', {
+        actions: [{ label: 'Action', onClick, href: '/page' }],
+      })
+    })
+
+    const actionLink = screen.getByText('Action')
+    await user.click(actionLink)
+
+    await waitFor(() => {
+      expect(onClick).toHaveBeenCalled()
+    })
+
+    vi.useFakeTimers()
+  })
 })

--- a/packages/core/src/notifications/Toast.tsx
+++ b/packages/core/src/notifications/Toast.tsx
@@ -206,22 +206,47 @@ export function Toast({ notification, onDismiss, onAutoDismiss }: ToastProps) {
             {/* Actions */}
             {notification.actions && notification.actions.length > 0 && (
               <div className="mt-3 flex space-x-3">
-                {notification.actions.map((action, index) => (
-                  <button
-                    key={index}
-                    onClick={async () => {
+                {notification.actions.map((action, index) => {
+                  const handleActionClick = async () => {
+                    if (action.onClick) {
                       await action.onClick()
-                      handleDismiss()
-                    }}
-                    className={`text-sm font-medium transition-colors ${
-                      action.primary
-                        ? 'text-blue-600 hover:text-blue-700'
-                        : 'text-gray-600 hover:text-gray-700'
-                    }`}
-                  >
-                    {action.label}
-                  </button>
-                ))}
+                    }
+                    if (action.href) {
+                      window.location.href = action.href
+                    }
+                    handleDismiss()
+                  }
+
+                  return action.href ? (
+                    <a
+                      key={index}
+                      href={action.href}
+                      onClick={(e) => {
+                        e.preventDefault()
+                        handleActionClick()
+                      }}
+                      className={`text-sm font-medium transition-colors ${
+                        action.primary
+                          ? 'text-blue-600 hover:text-blue-700'
+                          : 'text-gray-600 hover:text-gray-700'
+                      }`}
+                    >
+                      {action.label}
+                    </a>
+                  ) : (
+                    <button
+                      key={index}
+                      onClick={handleActionClick}
+                      className={`text-sm font-medium transition-colors ${
+                        action.primary
+                          ? 'text-blue-600 hover:text-blue-700'
+                          : 'text-gray-600 hover:text-gray-700'
+                      }`}
+                    >
+                      {action.label}
+                    </button>
+                  )
+                })}
               </div>
             )}
           </div>

--- a/packages/core/src/notifications/types.ts
+++ b/packages/core/src/notifications/types.ts
@@ -29,7 +29,10 @@ export interface NotificationAction {
   label: string
 
   /** Action callback */
-  onClick: () => void | Promise<void>
+  onClick?: () => void | Promise<void>
+
+  /** Navigation path */
+  href?: string
 
   /** Whether this is a primary action */
   primary?: boolean


### PR DESCRIPTION
Add href property to notification actions allowing direct navigation. Actions can now have onClick callback, href for navigation, or both.