### PR TITLE
Add table builder helper methods

### DIFF
--- a/packages/core/src/tables/builder.test.ts
+++ b/packages/core/src/tables/builder.test.ts
@@ -167,4 +167,59 @@ describe('TableBuilder', () => {
     expect(schema.searchable).toBe(true)
     expect(schema.searchPlaceholder).toBe('Search...')
   })
+
+  it('should add columns to existing column list', () => {
+    const builder = createTableBuilder()
+    const schema = builder
+      .columns([TextColumn.make('name').label('Name').build()])
+      .addColumns(
+        TextColumn.make('email').label('Email').build(),
+        NumberColumn.make('age').label('Age').build()
+      )
+      .build()
+
+    expect(schema.columns).toHaveLength(3)
+    expect(schema.columns[0].accessor).toBe('name')
+    expect(schema.columns[1].accessor).toBe('email')
+    expect(schema.columns[2].accessor).toBe('age')
+  })
+
+  it('should remove column by accessor', () => {
+    const builder = createTableBuilder()
+    const schema = builder
+      .columns([
+        TextColumn.make('name').label('Name').build(),
+        TextColumn.make('email').label('Email').build(),
+        NumberColumn.make('age').label('Age').build(),
+      ])
+      .removeColumn('email')
+      .build()
+
+    expect(schema.columns).toHaveLength(2)
+    expect(schema.columns[0].accessor).toBe('name')
+    expect(schema.columns[1].accessor).toBe('age')
+  })
+
+  it('should get column by accessor', () => {
+    const builder = createTableBuilder()
+    builder.columns([
+      TextColumn.make('name').label('Name').build(),
+      TextColumn.make('email').label('Email').build(),
+    ])
+
+    const column = builder.getColumn('email')
+
+    expect(column).toBeDefined()
+    expect(column?.accessor).toBe('email')
+    expect(column?.label).toBe('Email')
+  })
+
+  it('should return undefined when getting non-existent column', () => {
+    const builder = createTableBuilder()
+    builder.columns([TextColumn.make('name').label('Name').build()])
+
+    const column = builder.getColumn('nonexistent')
+
+    expect(column).toBeUndefined()
+  })
 })

--- a/packages/core/src/tables/builder.ts
+++ b/packages/core/src/tables/builder.ts
@@ -29,6 +29,29 @@ export class TableBuilder<TModel extends BaseModel = BaseModel> {
   }
 
   /**
+   * Add columns to the existing column list
+   */
+  addColumns(...columns: Column<TModel>[]): this {
+    this.columnList.push(...columns)
+    return this
+  }
+
+  /**
+   * Remove a column by accessor
+   */
+  removeColumn(accessor: keyof TModel | string): this {
+    this.columnList = this.columnList.filter((col) => col.accessor !== accessor)
+    return this
+  }
+
+  /**
+   * Get a column by accessor
+   */
+  getColumn(accessor: keyof TModel | string): Column<TModel> | undefined {
+    return this.columnList.find((col) => col.accessor === accessor)
+  }
+
+  /**
    * Add filters to the table
    */
   withFilters(filters: Filter[]): this {


### PR DESCRIPTION
Added three helper methods to TableBuilder for easier column manipulation:
- addColumns(...columns): Add multiple columns to existing list
- removeColumn(accessor): Remove a column by its accessor
- getColumn(accessor): Get a column by its accessor

These methods provide more flexibility when building tables incrementally.

Added 4 tests to verify the new functionality.