### PR TITLE
Add resource routing configuration and page metadata system

### DIFF
--- a/packages/core/src/types/resource.ts
+++ b/packages/core/src/types/resource.ts
@@ -124,6 +124,71 @@ export interface ResourceLifecycleHooks<TModel extends BaseModel = BaseModel> {
 }
 
 /**
+ * Routing configuration for resource pages
+ */
+export interface RoutingConfig {
+  /** Base path for the resource (e.g., '/users') */
+  basePath?: string
+
+  /** Custom route for list page */
+  listPath?: string
+
+  /** Custom route for create page */
+  createPath?: string
+
+  /** Custom route for edit page (use :id as placeholder) */
+  editPath?: string
+
+  /** Custom route for view page (use :id as placeholder) */
+  viewPath?: string
+
+  /** Whether to generate routes automatically */
+  autoGenerate?: boolean
+
+  /** Custom route parameter name (default: 'id') */
+  paramName?: string
+}
+
+/**
+ * Page metadata configuration
+ */
+export interface PageMetadata {
+  /** Page title template (use {name} for resource name, {id} for record id) */
+  title?: string
+
+  /** Page description */
+  description?: string
+
+  /** Custom meta tags */
+  meta?: Record<string, string>
+
+  /** Custom OpenGraph metadata */
+  og?: {
+    title?: string
+    description?: string
+    image?: string
+    type?: string
+  }
+}
+
+/**
+ * Resource page metadata
+ */
+export interface ResourcePageMetadata {
+  /** List page metadata */
+  list?: PageMetadata
+
+  /** Create page metadata */
+  create?: PageMetadata
+
+  /** Edit page metadata */
+  edit?: PageMetadata
+
+  /** View page metadata */
+  view?: PageMetadata
+}
+
+/**
  * Resource metadata
  */
 export interface ResourceMetadata {
@@ -135,6 +200,12 @@ export interface ResourceMetadata {
 
   /** Resource description */
   description?: string
+
+  /** Routing configuration */
+  routing?: RoutingConfig
+
+  /** Page metadata */
+  pageMetadata?: ResourcePageMetadata
 
   /** Custom metadata */
   [key: string]: unknown

--- a/packages/core/src/utils/breadcrumbs.test.ts
+++ b/packages/core/src/utils/breadcrumbs.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect } from 'vitest'
+import {
+  generateResourceBreadcrumbs,
+  createResourceBreadcrumbs,
+  type BreadcrumbItem,
+} from './breadcrumbs'
+import type { ModelDefinition } from '../types/resource'
+
+interface TestUser {
+  id: number
+  name: string
+  email: string
+}
+
+const testModel: ModelDefinition<TestUser> = {
+  name: 'User',
+  pluralName: 'Users',
+  endpoint: '/api/users',
+  displayField: 'name',
+}
+
+describe('generateResourceBreadcrumbs - list page', () => {
+  it('should generate breadcrumbs for list page', () => {
+    const breadcrumbs = generateResourceBreadcrumbs(testModel, 'list')
+
+    expect(breadcrumbs).toHaveLength(2)
+    expect(breadcrumbs[0]).toEqual({ label: 'Home', href: '/' })
+    expect(breadcrumbs[1]).toEqual({ label: 'Users', current: true })
+  })
+
+  it('should work without home breadcrumb', () => {
+    const breadcrumbs = generateResourceBreadcrumbs(testModel, 'list', {
+      config: { home: undefined },
+    })
+
+    expect(breadcrumbs).toHaveLength(1)
+    expect(breadcrumbs[0]).toEqual({ label: 'Users', current: true })
+  })
+
+  it('should include custom breadcrumbs', () => {
+    const breadcrumbs = generateResourceBreadcrumbs(testModel, 'list', {
+      customBreadcrumbs: [{ label: 'Admin', href: '/admin' }],
+    })
+
+    expect(breadcrumbs).toHaveLength(3)
+    expect(breadcrumbs[1]).toEqual({ label: 'Admin', href: '/admin' })
+    expect(breadcrumbs[2]).toEqual({ label: 'Users', current: true })
+  })
+})
+
+describe('generateResourceBreadcrumbs - create page', () => {
+  it('should generate breadcrumbs for create page', () => {
+    const breadcrumbs = generateResourceBreadcrumbs(testModel, 'create')
+
+    expect(breadcrumbs).toHaveLength(3)
+    expect(breadcrumbs[0]).toEqual({ label: 'Home', href: '/' })
+    expect(breadcrumbs[1]).toEqual({ label: 'Users', href: '/users' })
+    expect(breadcrumbs[2]).toEqual({ label: 'Create', current: true })
+  })
+
+  it('should link to list page', () => {
+    const breadcrumbs = generateResourceBreadcrumbs(testModel, 'create')
+
+    expect(breadcrumbs[1].href).toBe('/users')
+  })
+})
+
+describe('generateResourceBreadcrumbs - view page', () => {
+  it('should generate breadcrumbs for view page with id', () => {
+    const breadcrumbs = generateResourceBreadcrumbs(testModel, 'view', {
+      id: 123,
+    })
+
+    expect(breadcrumbs).toHaveLength(3)
+    expect(breadcrumbs[0]).toEqual({ label: 'Home', href: '/' })
+    expect(breadcrumbs[1]).toEqual({ label: 'Users', href: '/users' })
+    expect(breadcrumbs[2]).toEqual({ label: '#123', current: true })
+  })
+
+  it('should use displayField from record', () => {
+    const record: TestUser = { id: 123, name: 'John Doe', email: 'john@example.com' }
+    const breadcrumbs = generateResourceBreadcrumbs(testModel, 'view', {
+      id: 123,
+      record,
+    })
+
+    expect(breadcrumbs[2]).toEqual({ label: 'John Doe', current: true })
+  })
+
+  it('should fall back to id when displayField missing', () => {
+    const record: TestUser = { id: 123, name: '', email: 'john@example.com' }
+    const breadcrumbs = generateResourceBreadcrumbs(testModel, 'view', {
+      id: 123,
+      record,
+    })
+
+    expect(breadcrumbs[2].label).toBe('#123')
+  })
+
+  it('should work without record', () => {
+    const breadcrumbs = generateResourceBreadcrumbs(testModel, 'view', {
+      id: 456,
+    })
+
+    expect(breadcrumbs[2].label).toBe('#456')
+  })
+})
+
+describe('generateResourceBreadcrumbs - edit page', () => {
+  it('should generate breadcrumbs for edit page', () => {
+    const breadcrumbs = generateResourceBreadcrumbs(testModel, 'edit', {
+      id: 123,
+    })
+
+    expect(breadcrumbs).toHaveLength(4)
+    expect(breadcrumbs[0]).toEqual({ label: 'Home', href: '/' })
+    expect(breadcrumbs[1]).toEqual({ label: 'Users', href: '/users' })
+    expect(breadcrumbs[2]).toEqual({ label: '#123', href: '/users/123' })
+    expect(breadcrumbs[3]).toEqual({ label: 'Edit', current: true })
+  })
+
+  it('should use displayField from record', () => {
+    const record: TestUser = { id: 123, name: 'John Doe', email: 'john@example.com' }
+    const breadcrumbs = generateResourceBreadcrumbs(testModel, 'edit', {
+      id: 123,
+      record,
+    })
+
+    expect(breadcrumbs[2]).toEqual({ label: 'John Doe', href: '/users/123' })
+    expect(breadcrumbs[3]).toEqual({ label: 'Edit', current: true })
+  })
+
+  it('should link view breadcrumb to view page', () => {
+    const breadcrumbs = generateResourceBreadcrumbs(testModel, 'edit', {
+      id: 456,
+    })
+
+    expect(breadcrumbs[2].href).toBe('/users/456')
+  })
+})
+
+describe('Breadcrumb truncation', () => {
+  it('should not truncate when under maxItems', () => {
+    const breadcrumbs = generateResourceBreadcrumbs(testModel, 'edit', {
+      id: 123,
+      config: { maxItems: 10 },
+    })
+
+    expect(breadcrumbs).toHaveLength(4)
+    expect(breadcrumbs.some((b) => b.label === '...')).toBe(false)
+  })
+
+  it('should truncate when over maxItems', () => {
+    const customBreadcrumbs: BreadcrumbItem[] = [
+      { label: 'Admin', href: '/admin' },
+      { label: 'Organization', href: '/org' },
+      { label: 'Department', href: '/dept' },
+    ]
+
+    const breadcrumbs = generateResourceBreadcrumbs(testModel, 'edit', {
+      id: 123,
+      customBreadcrumbs,
+      config: { maxItems: 4 },
+    })
+
+    expect(breadcrumbs).toHaveLength(4)
+    expect(breadcrumbs[0].label).toBe('Home')
+    expect(breadcrumbs[1].label).toBe('...')
+    expect(breadcrumbs[breadcrumbs.length - 1].current).toBe(true)
+  })
+
+  it('should keep first and last items when truncating', () => {
+    const customBreadcrumbs: BreadcrumbItem[] = Array.from({ length: 10 }, (_, i) => ({
+      label: `Level ${i}`,
+      href: `/level${i}`,
+    }))
+
+    const breadcrumbs = generateResourceBreadcrumbs(testModel, 'list', {
+      customBreadcrumbs,
+      config: { maxItems: 4 },
+    })
+
+    expect(breadcrumbs[0].label).toBe('Home')
+    expect(breadcrumbs[1].label).toBe('...')
+    expect(breadcrumbs[breadcrumbs.length - 1].label).toBe('Users')
+  })
+})
+
+describe('Custom breadcrumb config', () => {
+  it('should use custom home breadcrumb', () => {
+    const breadcrumbs = generateResourceBreadcrumbs(testModel, 'list', {
+      config: {
+        home: { label: 'Dashboard', href: '/dashboard' },
+      },
+    })
+
+    expect(breadcrumbs[0]).toEqual({ label: 'Dashboard', href: '/dashboard' })
+  })
+
+  it('should handle missing home breadcrumb', () => {
+    const breadcrumbs = generateResourceBreadcrumbs(testModel, 'create', {
+      config: { home: undefined },
+    })
+
+    expect(breadcrumbs[0].label).not.toBe('Home')
+    expect(breadcrumbs[0].label).toBe('Users')
+  })
+})
+
+describe('ResourceBreadcrumbs helper', () => {
+  it('should generate list breadcrumbs', () => {
+    const helper = createResourceBreadcrumbs(testModel)
+    const breadcrumbs = helper.list()
+
+    expect(breadcrumbs[breadcrumbs.length - 1]).toEqual({
+      label: 'Users',
+      current: true,
+    })
+  })
+
+  it('should generate create breadcrumbs', () => {
+    const helper = createResourceBreadcrumbs(testModel)
+    const breadcrumbs = helper.create()
+
+    expect(breadcrumbs[breadcrumbs.length - 1]).toEqual({
+      label: 'Create',
+      current: true,
+    })
+  })
+
+  it('should generate view breadcrumbs', () => {
+    const helper = createResourceBreadcrumbs(testModel)
+    const breadcrumbs = helper.view(123)
+
+    expect(breadcrumbs[breadcrumbs.length - 1]).toEqual({
+      label: '#123',
+      current: true,
+    })
+  })
+
+  it('should generate edit breadcrumbs', () => {
+    const helper = createResourceBreadcrumbs(testModel)
+    const breadcrumbs = helper.edit(123)
+
+    expect(breadcrumbs[breadcrumbs.length - 1]).toEqual({
+      label: 'Edit',
+      current: true,
+    })
+  })
+
+  it('should pass custom breadcrumbs to all methods', () => {
+    const helper = createResourceBreadcrumbs(testModel, {
+      maxItems: 10, // Set high enough to prevent truncation
+    })
+    const custom: BreadcrumbItem[] = [{ label: 'Admin', href: '/admin' }]
+
+    const listBc = helper.list(custom)
+    const createBc = helper.create(custom)
+    const viewBc = helper.view(123, undefined, custom)
+    const editBc = helper.edit(123, undefined, custom)
+
+    expect(listBc[1]).toEqual({ label: 'Admin', href: '/admin' })
+    expect(createBc[1]).toEqual({ label: 'Admin', href: '/admin' })
+    expect(viewBc[1]).toEqual({ label: 'Admin', href: '/admin' })
+    expect(editBc[1]).toEqual({ label: 'Admin', href: '/admin' })
+  })
+
+  it('should use config from constructor', () => {
+    const helper = createResourceBreadcrumbs(testModel, {
+      home: { label: 'Dashboard', href: '/dash' },
+    })
+    const breadcrumbs = helper.list()
+
+    expect(breadcrumbs[0]).toEqual({ label: 'Dashboard', href: '/dash' })
+  })
+})
+
+describe('Model without displayField', () => {
+  it('should use id when no displayField defined', () => {
+    const model: ModelDefinition<TestUser> = {
+      name: 'User',
+      pluralName: 'Users',
+      endpoint: '/api/users',
+    }
+
+    const record: TestUser = { id: 123, name: 'John', email: 'john@example.com' }
+    const breadcrumbs = generateResourceBreadcrumbs(model, 'view', {
+      id: 123,
+      record,
+    })
+
+    expect(breadcrumbs[breadcrumbs.length - 1].label).toBe('#123')
+  })
+})
+
+describe('String IDs', () => {
+  it('should handle string IDs', () => {
+    const breadcrumbs = generateResourceBreadcrumbs(testModel, 'view', {
+      id: 'abc-123',
+    })
+
+    expect(breadcrumbs[breadcrumbs.length - 1].label).toBe('#abc-123')
+  })
+
+  it('should build paths with string IDs', () => {
+    const breadcrumbs = generateResourceBreadcrumbs(testModel, 'edit', {
+      id: 'uuid-123',
+    })
+
+    expect(breadcrumbs[2].href).toBe('/users/uuid-123')
+  })
+})

--- a/packages/core/src/utils/breadcrumbs.ts
+++ b/packages/core/src/utils/breadcrumbs.ts
@@ -1,0 +1,255 @@
+/**
+ * Breadcrumb generation utilities for resource pages
+ */
+
+import type { ModelDefinition, BaseModel } from '../types/resource'
+import { createResourceRoutes } from './routing'
+
+/**
+ * Breadcrumb item
+ */
+export interface BreadcrumbItem {
+  /** Breadcrumb label */
+  label: string
+
+  /** Breadcrumb link path */
+  href?: string
+
+  /** Whether this is the current page */
+  current?: boolean
+
+  /** Icon for the breadcrumb */
+  icon?: React.ReactNode | string
+}
+
+/**
+ * Breadcrumb configuration
+ */
+export interface BreadcrumbConfig {
+  /** Home breadcrumb */
+  home?: BreadcrumbItem
+
+  /** Maximum breadcrumbs to show before truncating */
+  maxItems?: number
+
+  /** Separator between breadcrumbs */
+  separator?: React.ReactNode | string
+
+  /** Whether to show icons */
+  showIcons?: boolean
+}
+
+/**
+ * Page type for breadcrumb generation
+ */
+export type PageType = 'list' | 'create' | 'edit' | 'view'
+
+/**
+ * Default breadcrumb configuration
+ */
+const DEFAULT_BREADCRUMB_CONFIG: Required<BreadcrumbConfig> = {
+  home: { label: 'Home', href: '/' },
+  maxItems: 4,
+  separator: '/',
+  showIcons: false,
+}
+
+/**
+ * Generate breadcrumbs for a resource page
+ */
+export function generateResourceBreadcrumbs<TModel extends BaseModel>(
+  model: ModelDefinition<TModel>,
+  pageType: PageType,
+  options?: {
+    id?: string | number
+    record?: TModel
+    config?: BreadcrumbConfig
+    customBreadcrumbs?: BreadcrumbItem[]
+  }
+): BreadcrumbItem[] {
+  const config = { ...DEFAULT_BREADCRUMB_CONFIG, ...options?.config }
+  const routes = createResourceRoutes(model)
+  const breadcrumbs: BreadcrumbItem[] = []
+
+  // Add home breadcrumb if configured
+  if (config.home) {
+    breadcrumbs.push(config.home)
+  }
+
+  // Add custom breadcrumbs before resource breadcrumbs
+  if (options?.customBreadcrumbs) {
+    breadcrumbs.push(...options.customBreadcrumbs)
+  }
+
+  const pluralName = model.pluralName || `${model.name}s`
+
+  // Add resource list breadcrumb (except when on list page)
+  if (pageType !== 'list') {
+    breadcrumbs.push({
+      label: pluralName,
+      href: routes.list(),
+    })
+  }
+
+  // Add page-specific breadcrumb
+  switch (pageType) {
+    case 'list':
+      breadcrumbs.push({
+        label: pluralName,
+        current: true,
+      })
+      break
+
+    case 'create':
+      breadcrumbs.push({
+        label: 'Create',
+        current: true,
+      })
+      break
+
+    case 'edit':
+      if (options?.id) {
+        // Add view breadcrumb
+        breadcrumbs.push({
+          label: getRecordLabel(model, options.record, options.id),
+          href: routes.view(options.id),
+        })
+        // Add edit breadcrumb
+        breadcrumbs.push({
+          label: 'Edit',
+          current: true,
+        })
+      }
+      break
+
+    case 'view':
+      if (options?.id) {
+        breadcrumbs.push({
+          label: getRecordLabel(model, options.record, options.id),
+          current: true,
+        })
+      }
+      break
+  }
+
+  // Truncate breadcrumbs if needed
+  return truncateBreadcrumbs(breadcrumbs, config.maxItems)
+}
+
+/**
+ * Get label for a record
+ */
+function getRecordLabel<TModel extends BaseModel>(
+  model: ModelDefinition<TModel>,
+  record?: TModel,
+  id?: string | number
+): string {
+  if (record && model.displayField && record[model.displayField]) {
+    return String(record[model.displayField])
+  }
+
+  return `#${id}`
+}
+
+/**
+ * Truncate breadcrumbs to max items
+ */
+function truncateBreadcrumbs(
+  breadcrumbs: BreadcrumbItem[],
+  maxItems: number
+): BreadcrumbItem[] {
+  if (breadcrumbs.length <= maxItems) {
+    return breadcrumbs
+  }
+
+  // Keep first (home), last (current), and fit middle items
+  const result: BreadcrumbItem[] = []
+
+  // Always keep first item (home)
+  result.push(breadcrumbs[0])
+
+  // Add ellipsis
+  result.push({
+    label: '...',
+    current: false,
+  })
+
+  // Add last items
+  const remainingSlots = maxItems - 2 // -2 for home and ellipsis
+  const startIndex = breadcrumbs.length - remainingSlots
+  result.push(...breadcrumbs.slice(startIndex))
+
+  return result
+}
+
+/**
+ * Resource breadcrumb helper
+ */
+export class ResourceBreadcrumbs<TModel extends BaseModel> {
+  constructor(
+    private model: ModelDefinition<TModel>,
+    private config?: BreadcrumbConfig
+  ) {}
+
+  /**
+   * Get breadcrumbs for list page
+   */
+  list(customBreadcrumbs?: BreadcrumbItem[]): BreadcrumbItem[] {
+    return generateResourceBreadcrumbs(this.model, 'list', {
+      config: this.config,
+      customBreadcrumbs,
+    })
+  }
+
+  /**
+   * Get breadcrumbs for create page
+   */
+  create(customBreadcrumbs?: BreadcrumbItem[]): BreadcrumbItem[] {
+    return generateResourceBreadcrumbs(this.model, 'create', {
+      config: this.config,
+      customBreadcrumbs,
+    })
+  }
+
+  /**
+   * Get breadcrumbs for edit page
+   */
+  edit(
+    id: string | number,
+    record?: TModel,
+    customBreadcrumbs?: BreadcrumbItem[]
+  ): BreadcrumbItem[] {
+    return generateResourceBreadcrumbs(this.model, 'edit', {
+      id,
+      record,
+      config: this.config,
+      customBreadcrumbs,
+    })
+  }
+
+  /**
+   * Get breadcrumbs for view page
+   */
+  view(
+    id: string | number,
+    record?: TModel,
+    customBreadcrumbs?: BreadcrumbItem[]
+  ): BreadcrumbItem[] {
+    return generateResourceBreadcrumbs(this.model, 'view', {
+      id,
+      record,
+      config: this.config,
+      customBreadcrumbs,
+    })
+  }
+}
+
+/**
+ * Create a resource breadcrumb helper
+ */
+export function createResourceBreadcrumbs<TModel extends BaseModel>(
+  model: ModelDefinition<TModel>,
+  config?: BreadcrumbConfig
+): ResourceBreadcrumbs<TModel> {
+  return new ResourceBreadcrumbs(model, config)
+}

--- a/packages/core/src/utils/metadata.test.ts
+++ b/packages/core/src/utils/metadata.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getListPageMetadata,
+  getCreatePageMetadata,
+  getEditPageMetadata,
+  getViewPageMetadata,
+  createResourceMetadata,
+} from './metadata'
+import type { ModelDefinition } from '../types/resource'
+
+interface TestUser {
+  id: number
+  name: string
+  email: string
+}
+
+const testModel: ModelDefinition<TestUser> = {
+  name: 'User',
+  pluralName: 'Users',
+  endpoint: '/api/users',
+  displayField: 'name',
+}
+
+describe('getListPageMetadata', () => {
+  it('should generate default list page metadata', () => {
+    const metadata = getListPageMetadata(testModel)
+
+    expect(metadata.title).toBe('Users')
+    expect(metadata.description).toBe('Browse and manage Users')
+  })
+
+  it('should use custom metadata', () => {
+    const metadata = getListPageMetadata(testModel, {
+      title: 'All Users',
+      description: 'View all registered users',
+    })
+
+    expect(metadata.title).toBe('All Users')
+    expect(metadata.description).toBe('View all registered users')
+  })
+
+  it('should replace template variables', () => {
+    const metadata = getListPageMetadata(testModel, {
+      title: 'Manage {pluralName}',
+      description: 'List of all {pluralName} in the system',
+    })
+
+    expect(metadata.title).toBe('Manage Users')
+    expect(metadata.description).toBe('List of all Users in the system')
+  })
+
+  it('should handle missing pluralName', () => {
+    const model: ModelDefinition<TestUser> = {
+      name: 'User',
+      endpoint: '/api/users',
+    }
+
+    const metadata = getListPageMetadata(model)
+
+    expect(metadata.title).toBe('Users')
+  })
+})
+
+describe('getCreatePageMetadata', () => {
+  it('should generate default create page metadata', () => {
+    const metadata = getCreatePageMetadata(testModel)
+
+    expect(metadata.title).toBe('Create User')
+    expect(metadata.description).toBe('Create a new User')
+  })
+
+  it('should use custom metadata', () => {
+    const metadata = getCreatePageMetadata(testModel, {
+      title: 'Add New User',
+      description: 'Register a new user account',
+    })
+
+    expect(metadata.title).toBe('Add New User')
+    expect(metadata.description).toBe('Register a new user account')
+  })
+
+  it('should replace template variables', () => {
+    const metadata = getCreatePageMetadata(testModel, {
+      title: 'New {name}',
+      description: 'Add a new {name} to the system',
+    })
+
+    expect(metadata.title).toBe('New User')
+    expect(metadata.description).toBe('Add a new User to the system')
+  })
+})
+
+describe('getEditPageMetadata', () => {
+  it('should generate default edit page metadata', () => {
+    const metadata = getEditPageMetadata(testModel, 123)
+
+    expect(metadata.title).toBe('Edit User')
+    expect(metadata.description).toBe('Edit User details')
+  })
+
+  it('should use custom metadata', () => {
+    const metadata = getEditPageMetadata(testModel, 123, undefined, {
+      title: 'Update User',
+      description: 'Modify user information',
+    })
+
+    expect(metadata.title).toBe('Update User')
+    expect(metadata.description).toBe('Modify user information')
+  })
+
+  it('should replace template variables including id', () => {
+    const metadata = getEditPageMetadata(testModel, 123, undefined, {
+      title: 'Edit {name} #{id}',
+      description: 'Update {name} with ID {id}',
+    })
+
+    expect(metadata.title).toBe('Edit User #123')
+    expect(metadata.description).toBe('Update User with ID 123')
+  })
+
+  it('should accept record parameter', () => {
+    const record: TestUser = { id: 123, name: 'John Doe', email: 'john@example.com' }
+    const metadata = getEditPageMetadata(testModel, 123, record)
+
+    expect(metadata.title).toBe('Edit User')
+  })
+})
+
+describe('getViewPageMetadata', () => {
+  it('should generate default view page metadata', () => {
+    const metadata = getViewPageMetadata(testModel, 123)
+
+    expect(metadata.title).toBe('View User')
+    expect(metadata.description).toBe('View User details')
+  })
+
+  it('should use custom metadata', () => {
+    const metadata = getViewPageMetadata(testModel, 123, undefined, {
+      title: 'User Details',
+      description: 'View user profile',
+    })
+
+    expect(metadata.title).toBe('User Details')
+    expect(metadata.description).toBe('View user profile')
+  })
+
+  it('should replace template variables', () => {
+    const metadata = getViewPageMetadata(testModel, 456, undefined, {
+      title: '{name} #{id}',
+      description: 'Details for {name} {id}',
+    })
+
+    expect(metadata.title).toBe('User #456')
+    expect(metadata.description).toBe('Details for User 456')
+  })
+})
+
+describe('ResourceMetadataHelper', () => {
+  it('should generate list metadata', () => {
+    const helper = createResourceMetadata(testModel)
+    const metadata = helper.list()
+
+    expect(metadata.title).toBe('Users')
+    expect(metadata.description).toBe('Browse and manage Users')
+  })
+
+  it('should generate create metadata', () => {
+    const helper = createResourceMetadata(testModel)
+    const metadata = helper.create()
+
+    expect(metadata.title).toBe('Create User')
+  })
+
+  it('should generate edit metadata', () => {
+    const helper = createResourceMetadata(testModel)
+    const metadata = helper.edit(123)
+
+    expect(metadata.title).toBe('Edit User')
+  })
+
+  it('should generate view metadata', () => {
+    const helper = createResourceMetadata(testModel)
+    const metadata = helper.view(123)
+
+    expect(metadata.title).toBe('View User')
+  })
+
+  it('should use custom metadata for all pages', () => {
+    const helper = createResourceMetadata(testModel, {
+      list: { title: 'All Users' },
+      create: { title: 'Add User' },
+      edit: { title: 'Update User' },
+      view: { title: 'User Profile' },
+    })
+
+    expect(helper.list().title).toBe('All Users')
+    expect(helper.create().title).toBe('Add User')
+    expect(helper.edit(123).title).toBe('Update User')
+    expect(helper.view(123).title).toBe('User Profile')
+  })
+
+  it('should pass record to edit metadata', () => {
+    const helper = createResourceMetadata(testModel)
+    const record: TestUser = { id: 123, name: 'John', email: 'john@example.com' }
+    const metadata = helper.edit(123, record)
+
+    expect(metadata.title).toBe('Edit User')
+  })
+
+  it('should pass record to view metadata', () => {
+    const helper = createResourceMetadata(testModel)
+    const record: TestUser = { id: 123, name: 'John', email: 'john@example.com' }
+    const metadata = helper.view(123, record)
+
+    expect(metadata.title).toBe('View User')
+  })
+})
+
+describe('OpenGraph metadata', () => {
+  it('should process og metadata templates', () => {
+    const metadata = getListPageMetadata(testModel, {
+      title: '{pluralName}',
+      og: {
+        title: '{pluralName} - Admin',
+        description: 'Manage {pluralName}',
+      },
+    })
+
+    expect(metadata.og?.title).toBe('Users - Admin')
+    expect(metadata.og?.description).toBe('Manage Users')
+  })
+
+  it('should preserve og metadata without templates', () => {
+    const metadata = getListPageMetadata(testModel, {
+      og: {
+        title: 'Users',
+        image: 'https://example.com/image.png',
+        type: 'website',
+      },
+    })
+
+    expect(metadata.og?.title).toBe('Users')
+    expect(metadata.og?.image).toBe('https://example.com/image.png')
+    expect(metadata.og?.type).toBe('website')
+  })
+})
+
+describe('Custom meta tags', () => {
+  it('should preserve custom meta tags', () => {
+    const metadata = getListPageMetadata(testModel, {
+      meta: {
+        keywords: 'users, admin, management',
+        author: 'Filact',
+      },
+    })
+
+    expect(metadata.meta).toEqual({
+      keywords: 'users, admin, management',
+      author: 'Filact',
+    })
+  })
+})

--- a/packages/core/src/utils/metadata.ts
+++ b/packages/core/src/utils/metadata.ts
@@ -1,0 +1,201 @@
+/**
+ * Page metadata utilities for resource pages
+ */
+
+import type { PageMetadata, ResourcePageMetadata, ModelDefinition, BaseModel } from '../types/resource'
+
+/**
+ * Template variable replacements
+ */
+interface MetadataContext {
+  /** Resource name */
+  name: string
+
+  /** Plural resource name */
+  pluralName: string
+
+  /** Record ID (for edit/view pages) */
+  id?: string | number
+
+  /** Record data (for custom templates) */
+  record?: Record<string, unknown>
+}
+
+/**
+ * Replace template variables in a string
+ */
+function replaceTemplateVars(template: string, context: MetadataContext): string {
+  return template
+    .replace(/{name}/g, context.name)
+    .replace(/{pluralName}/g, context.pluralName)
+    .replace(/{id}/g, context.id ? String(context.id) : '')
+}
+
+/**
+ * Replace template variables in page metadata
+ */
+function processPageMetadata(metadata: PageMetadata, context: MetadataContext): PageMetadata {
+  const processed: PageMetadata = { ...metadata }
+
+  if (processed.title) {
+    processed.title = replaceTemplateVars(processed.title, context)
+  }
+
+  if (processed.description) {
+    processed.description = replaceTemplateVars(processed.description, context)
+  }
+
+  if (processed.og) {
+    processed.og = { ...processed.og }
+    if (processed.og.title) {
+      processed.og.title = replaceTemplateVars(processed.og.title, context)
+    }
+    if (processed.og.description) {
+      processed.og.description = replaceTemplateVars(processed.og.description, context)
+    }
+  }
+
+  return processed
+}
+
+/**
+ * Default page metadata templates
+ */
+const DEFAULT_PAGE_METADATA: ResourcePageMetadata = {
+  list: {
+    title: '{pluralName}',
+    description: 'Browse and manage {pluralName}',
+  },
+  create: {
+    title: 'Create {name}',
+    description: 'Create a new {name}',
+  },
+  edit: {
+    title: 'Edit {name}',
+    description: 'Edit {name} details',
+  },
+  view: {
+    title: 'View {name}',
+    description: 'View {name} details',
+  },
+}
+
+/**
+ * Get page metadata for list page
+ */
+export function getListPageMetadata<TModel extends BaseModel>(
+  model: ModelDefinition<TModel>,
+  customMetadata?: PageMetadata
+): PageMetadata {
+  const metadata = { ...DEFAULT_PAGE_METADATA.list, ...customMetadata }
+  const context: MetadataContext = {
+    name: model.name,
+    pluralName: model.pluralName || `${model.name}s`,
+  }
+
+  return processPageMetadata(metadata, context)
+}
+
+/**
+ * Get page metadata for create page
+ */
+export function getCreatePageMetadata<TModel extends BaseModel>(
+  model: ModelDefinition<TModel>,
+  customMetadata?: PageMetadata
+): PageMetadata {
+  const metadata = { ...DEFAULT_PAGE_METADATA.create, ...customMetadata }
+  const context: MetadataContext = {
+    name: model.name,
+    pluralName: model.pluralName || `${model.name}s`,
+  }
+
+  return processPageMetadata(metadata, context)
+}
+
+/**
+ * Get page metadata for edit page
+ */
+export function getEditPageMetadata<TModel extends BaseModel>(
+  model: ModelDefinition<TModel>,
+  id: string | number,
+  record?: TModel,
+  customMetadata?: PageMetadata
+): PageMetadata {
+  const metadata = { ...DEFAULT_PAGE_METADATA.edit, ...customMetadata }
+  const context: MetadataContext = {
+    name: model.name,
+    pluralName: model.pluralName || `${model.name}s`,
+    id,
+    record: record as Record<string, unknown>,
+  }
+
+  return processPageMetadata(metadata, context)
+}
+
+/**
+ * Get page metadata for view page
+ */
+export function getViewPageMetadata<TModel extends BaseModel>(
+  model: ModelDefinition<TModel>,
+  id: string | number,
+  record?: TModel,
+  customMetadata?: PageMetadata
+): PageMetadata {
+  const metadata = { ...DEFAULT_PAGE_METADATA.view, ...customMetadata }
+  const context: MetadataContext = {
+    name: model.name,
+    pluralName: model.pluralName || `${model.name}s`,
+    id,
+    record: record as Record<string, unknown>,
+  }
+
+  return processPageMetadata(metadata, context)
+}
+
+/**
+ * Resource metadata helper
+ */
+export class ResourceMetadataHelper<TModel extends BaseModel> {
+  constructor(
+    private model: ModelDefinition<TModel>,
+    private customMetadata?: ResourcePageMetadata
+  ) {}
+
+  /**
+   * Get metadata for list page
+   */
+  list(): PageMetadata {
+    return getListPageMetadata(this.model, this.customMetadata?.list)
+  }
+
+  /**
+   * Get metadata for create page
+   */
+  create(): PageMetadata {
+    return getCreatePageMetadata(this.model, this.customMetadata?.create)
+  }
+
+  /**
+   * Get metadata for edit page
+   */
+  edit(id: string | number, record?: TModel): PageMetadata {
+    return getEditPageMetadata(this.model, id, record, this.customMetadata?.edit)
+  }
+
+  /**
+   * Get metadata for view page
+   */
+  view(id: string | number, record?: TModel): PageMetadata {
+    return getViewPageMetadata(this.model, id, record, this.customMetadata?.view)
+  }
+}
+
+/**
+ * Create a resource metadata helper
+ */
+export function createResourceMetadata<TModel extends BaseModel>(
+  model: ModelDefinition<TModel>,
+  customMetadata?: ResourcePageMetadata
+): ResourceMetadataHelper<TModel> {
+  return new ResourceMetadataHelper(model, customMetadata)
+}

--- a/packages/core/src/utils/routing.test.ts
+++ b/packages/core/src/utils/routing.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from 'vitest'
+import {
+  generateResourceRoutes,
+  buildRoutePath,
+  parseRouteParams,
+  createResourceRoutes,
+  DEFAULT_ROUTING,
+} from './routing'
+import type { ModelDefinition } from '../types/resource'
+
+interface TestUser {
+  id: number
+  name: string
+  email: string
+}
+
+const testModel: ModelDefinition<TestUser> = {
+  name: 'User',
+  pluralName: 'Users',
+  endpoint: '/api/users',
+}
+
+describe('generateResourceRoutes', () => {
+  it('should generate default routes from model', () => {
+    const routes = generateResourceRoutes(testModel)
+
+    expect(routes.basePath).toBe('/users')
+    expect(routes.listPath).toBe('/users')
+    expect(routes.createPath).toBe('/users/create')
+    expect(routes.editPath).toBe('/users/:id/edit')
+    expect(routes.viewPath).toBe('/users/:id')
+  })
+
+  it('should use custom basePath', () => {
+    const routes = generateResourceRoutes(testModel, {
+      basePath: '/admin/users',
+    })
+
+    expect(routes.basePath).toBe('/admin/users')
+    expect(routes.listPath).toBe('/admin/users')
+    expect(routes.createPath).toBe('/admin/users/create')
+  })
+
+  it('should use custom route paths', () => {
+    const routes = generateResourceRoutes(testModel, {
+      basePath: '/users',
+      createPath: '/new',
+      editPath: '/:id/update',
+    })
+
+    expect(routes.createPath).toBe('/users/new')
+    expect(routes.editPath).toBe('/users/:id/update')
+  })
+
+  it('should respect autoGenerate: false', () => {
+    const routes = generateResourceRoutes(testModel, {
+      autoGenerate: false,
+      basePath: '/custom',
+      listPath: '/all',
+      createPath: '/add',
+    })
+
+    expect(routes.basePath).toBe('/custom')
+    expect(routes.listPath).toBe('/all')
+    expect(routes.createPath).toBe('/add')
+  })
+
+  it('should use custom paramName', () => {
+    const routes = generateResourceRoutes(testModel, {
+      paramName: 'userId',
+    })
+
+    expect(routes.editPath).toBe('/users/:userId/edit')
+    expect(routes.viewPath).toBe('/users/:userId')
+  })
+
+  it('should generate basePath from model name when pluralName missing', () => {
+    const model: ModelDefinition<TestUser> = {
+      name: 'User',
+      endpoint: '/api/users',
+    }
+
+    const routes = generateResourceRoutes(model)
+
+    expect(routes.basePath).toBe('/users')
+  })
+
+  it('should handle lowercase model names', () => {
+    const model: ModelDefinition<TestUser> = {
+      name: 'user',
+      pluralName: 'Users',
+      endpoint: '/api/users',
+    }
+
+    const routes = generateResourceRoutes(model)
+
+    expect(routes.basePath).toBe('/users')
+  })
+})
+
+describe('buildRoutePath', () => {
+  it('should replace single parameter', () => {
+    const path = buildRoutePath('/users/:id', { id: 123 })
+
+    expect(path).toBe('/users/123')
+  })
+
+  it('should replace multiple parameters', () => {
+    const path = buildRoutePath('/organizations/:orgId/users/:userId', {
+      orgId: 'abc',
+      userId: 456,
+    })
+
+    expect(path).toBe('/organizations/abc/users/456')
+  })
+
+  it('should handle string and number parameters', () => {
+    const path1 = buildRoutePath('/users/:id', { id: 'abc-123' })
+    const path2 = buildRoutePath('/users/:id', { id: 999 })
+
+    expect(path1).toBe('/users/abc-123')
+    expect(path2).toBe('/users/999')
+  })
+
+  it('should leave unreplaced parameters as-is', () => {
+    const path = buildRoutePath('/users/:id/posts/:postId', { id: 123 })
+
+    expect(path).toBe('/users/123/posts/:postId')
+  })
+})
+
+describe('parseRouteParams', () => {
+  it('should parse single parameter', () => {
+    const params = parseRouteParams('/users/:id', '/users/123')
+
+    expect(params).toEqual({ id: '123' })
+  })
+
+  it('should parse multiple parameters', () => {
+    const params = parseRouteParams(
+      '/organizations/:orgId/users/:userId',
+      '/organizations/abc/users/456'
+    )
+
+    expect(params).toEqual({ orgId: 'abc', userId: '456' })
+  })
+
+  it('should return null for non-matching paths', () => {
+    const params = parseRouteParams('/users/:id', '/posts/123')
+
+    expect(params).toBeNull()
+  })
+
+  it('should handle paths with trailing content', () => {
+    const params = parseRouteParams('/users/:id/edit', '/users/123/edit')
+
+    expect(params).toEqual({ id: '123' })
+  })
+
+  it('should return null for partial matches', () => {
+    const params = parseRouteParams('/users/:id/edit', '/users/123')
+
+    expect(params).toBeNull()
+  })
+
+  it('should handle complex parameter values', () => {
+    const params = parseRouteParams('/users/:id', '/users/abc-123-def')
+
+    expect(params).toEqual({ id: 'abc-123-def' })
+  })
+})
+
+describe('ResourceRoutes', () => {
+  it('should generate list route', () => {
+    const routes = createResourceRoutes(testModel)
+
+    expect(routes.list()).toBe('/users')
+  })
+
+  it('should generate create route', () => {
+    const routes = createResourceRoutes(testModel)
+
+    expect(routes.create()).toBe('/users/create')
+  })
+
+  it('should generate edit route with id', () => {
+    const routes = createResourceRoutes(testModel)
+
+    expect(routes.edit(123)).toBe('/users/123/edit')
+    expect(routes.edit('abc')).toBe('/users/abc/edit')
+  })
+
+  it('should generate view route with id', () => {
+    const routes = createResourceRoutes(testModel)
+
+    expect(routes.view(123)).toBe('/users/123')
+    expect(routes.view('abc')).toBe('/users/abc')
+  })
+
+  it('should return all route templates', () => {
+    const routes = createResourceRoutes(testModel)
+    const templates = routes.templates()
+
+    expect(templates.basePath).toBe('/users')
+    expect(templates.listPath).toBe('/users')
+    expect(templates.createPath).toBe('/users/create')
+    expect(templates.editPath).toBe('/users/:id/edit')
+    expect(templates.viewPath).toBe('/users/:id')
+  })
+
+  it('should work with custom configuration', () => {
+    const routes = createResourceRoutes(testModel, {
+      basePath: '/admin/users',
+      paramName: 'userId',
+    })
+
+    expect(routes.list()).toBe('/admin/users')
+    expect(routes.create()).toBe('/admin/users/create')
+    expect(routes.edit(123)).toBe('/admin/users/123/edit')
+    expect(routes.view(123)).toBe('/admin/users/123')
+  })
+})
+
+describe('DEFAULT_ROUTING', () => {
+  it('should have expected default values', () => {
+    expect(DEFAULT_ROUTING.basePath).toBe('')
+    expect(DEFAULT_ROUTING.listPath).toBe('')
+    expect(DEFAULT_ROUTING.createPath).toBe('/create')
+    expect(DEFAULT_ROUTING.editPath).toBe('/:id/edit')
+    expect(DEFAULT_ROUTING.viewPath).toBe('/:id')
+    expect(DEFAULT_ROUTING.autoGenerate).toBe(true)
+    expect(DEFAULT_ROUTING.paramName).toBe('id')
+  })
+})

--- a/packages/core/src/utils/routing.ts
+++ b/packages/core/src/utils/routing.ts
@@ -1,0 +1,162 @@
+/**
+ * Routing utilities for resource pages
+ */
+
+import type { RoutingConfig, ModelDefinition, BaseModel } from '../types/resource'
+
+/**
+ * Default routing configuration
+ */
+export const DEFAULT_ROUTING: Required<RoutingConfig> = {
+  basePath: '',
+  listPath: '',
+  createPath: '/create',
+  editPath: '/:id/edit',
+  viewPath: '/:id',
+  autoGenerate: true,
+  paramName: 'id',
+}
+
+/**
+ * Generate route paths for a resource
+ */
+export function generateResourceRoutes<TModel extends BaseModel>(
+  model: ModelDefinition<TModel>,
+  config?: RoutingConfig
+): Required<RoutingConfig> {
+  const routing = { ...DEFAULT_ROUTING, ...config }
+
+  // Use basePath from config or generate from model name
+  if (!routing.basePath) {
+    const pluralName = model.pluralName || `${model.name}s`
+    routing.basePath = `/${pluralName.toLowerCase()}`
+  }
+
+  // If not auto-generating, return custom paths as-is
+  if (!routing.autoGenerate) {
+    return routing
+  }
+
+  // Generate full paths by combining basePath with route paths
+  // Replace :id with custom paramName if provided
+  const editPathTemplate = routing.editPath || `/:${routing.paramName}/edit`
+  const viewPathTemplate = routing.viewPath || `/:${routing.paramName}`
+
+  const fullPaths: Required<RoutingConfig> = {
+    basePath: routing.basePath,
+    listPath: routing.basePath + (routing.listPath || ''),
+    createPath: routing.basePath + (routing.createPath || '/create'),
+    editPath: routing.basePath + editPathTemplate.replace(':id', `:${routing.paramName}`),
+    viewPath: routing.basePath + viewPathTemplate.replace(':id', `:${routing.paramName}`),
+    autoGenerate: routing.autoGenerate,
+    paramName: routing.paramName,
+  }
+
+  return fullPaths
+}
+
+/**
+ * Build a route path with parameters
+ */
+export function buildRoutePath(
+  pathTemplate: string,
+  params: Record<string, string | number>
+): string {
+  let path = pathTemplate
+
+  // Replace each parameter in the path
+  Object.entries(params).forEach(([key, value]) => {
+    path = path.replace(`:${key}`, String(value))
+  })
+
+  return path
+}
+
+/**
+ * Parse route parameters from a path
+ */
+export function parseRouteParams(
+  pathTemplate: string,
+  actualPath: string
+): Record<string, string> | null {
+  // Convert template to regex pattern
+  const pattern = pathTemplate.replace(/:([^/]+)/g, '([^/]+)')
+  const regex = new RegExp(`^${pattern}$`)
+
+  const match = actualPath.match(regex)
+  if (!match) {
+    return null
+  }
+
+  // Extract parameter names from template
+  const paramNames: string[] = []
+  const paramRegex = /:([^/]+)/g
+  let paramMatch
+  while ((paramMatch = paramRegex.exec(pathTemplate)) !== null) {
+    paramNames.push(paramMatch[1])
+  }
+
+  // Build params object
+  const params: Record<string, string> = {}
+  paramNames.forEach((name, index) => {
+    params[name] = match[index + 1]
+  })
+
+  return params
+}
+
+/**
+ * Resource route builder helper
+ */
+export class ResourceRoutes<TModel extends BaseModel> {
+  private config: Required<RoutingConfig>
+
+  constructor(model: ModelDefinition<TModel>, config?: RoutingConfig) {
+    this.config = generateResourceRoutes(model, config)
+  }
+
+  /**
+   * Get list page route
+   */
+  list(): string {
+    return this.config.listPath
+  }
+
+  /**
+   * Get create page route
+   */
+  create(): string {
+    return this.config.createPath
+  }
+
+  /**
+   * Get edit page route for a record
+   */
+  edit(id: string | number): string {
+    return buildRoutePath(this.config.editPath, { [this.config.paramName]: id })
+  }
+
+  /**
+   * Get view page route for a record
+   */
+  view(id: string | number): string {
+    return buildRoutePath(this.config.viewPath, { [this.config.paramName]: id })
+  }
+
+  /**
+   * Get all route templates
+   */
+  templates(): Required<RoutingConfig> {
+    return { ...this.config }
+  }
+}
+
+/**
+ * Create a resource routes helper
+ */
+export function createResourceRoutes<TModel extends BaseModel>(
+  model: ModelDefinition<TModel>,
+  config?: RoutingConfig
+): ResourceRoutes<TModel> {
+  return new ResourceRoutes(model, config)
+}


### PR DESCRIPTION
Implemented:
- RoutingConfig interface for customizable resource page routes
- PageMetadata and ResourcePageMetadata for page titles and SEO
- generateResourceRoutes() with auto-generation and custom paths
- ResourceRoutes helper class for generating typed routes
- buildRoutePath() and parseRouteParams() utilities
- Page metadata helpers (getListPageMetadata, getCreatePageMetadata, etc.)
- ResourceMetadataHelper class for managing page metadata
- Template variable replacement in titles and descriptions
- OpenGraph and custom meta tag support
- Breadcrumb generation utilities with BreadcrumbItem interface
- generateResourceBreadcrumbs() for all page types
- Breadcrumb truncation with maxItems support
- ResourceBreadcrumbs helper class
- Custom breadcrumb configuration support

Added 74 comprehensive tests across:
- routing.test.ts (24 tests)
- metadata.test.ts (24 tests)
- breadcrumbs.test.ts (26 tests)

All tests passing. Supports Story 2.3 requirements for routing configuration and breadcrumb generation.

Generated with Claude Code