### PR TITLE
Add filter presets/saved filters functionality

### DIFF
--- a/packages/core/src/tables/FilterPresets.test.tsx
+++ b/packages/core/src/tables/FilterPresets.test.tsx
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FilterPresets, type FilterPreset } from './FilterPresets'
+
+const mockPresets: FilterPreset[] = [
+  {
+    id: '1',
+    name: 'Active Users',
+    filters: { status: 'active' },
+    description: 'Show only active users',
+  },
+  {
+    id: '2',
+    name: 'Admins',
+    filters: { role: 'admin' },
+  },
+  {
+    id: '3',
+    name: 'Default',
+    filters: {},
+    isDefault: true,
+  },
+]
+
+describe('FilterPresets', () => {
+  it('should render presets list', () => {
+    render(
+      <FilterPresets
+        presets={mockPresets}
+        onApplyPreset={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Active Users')).toBeInTheDocument()
+    expect(screen.getByText('Admins')).toBeInTheDocument()
+    expect(screen.getByText('Default')).toBeInTheDocument()
+  })
+
+  it('should display preset descriptions', () => {
+    render(
+      <FilterPresets
+        presets={mockPresets}
+        onApplyPreset={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Show only active users')).toBeInTheDocument()
+  })
+
+  it('should mark default preset', () => {
+    render(
+      <FilterPresets
+        presets={mockPresets}
+        onApplyPreset={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('(Default)')).toBeInTheDocument()
+  })
+
+  it('should call onApplyPreset when preset clicked', async () => {
+    const onApplyPreset = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <FilterPresets
+        presets={mockPresets}
+        onApplyPreset={onApplyPreset}
+      />
+    )
+
+    await user.click(screen.getByText('Active Users'))
+
+    expect(onApplyPreset).toHaveBeenCalledWith(mockPresets[0])
+  })
+
+  it('should show "Save as preset" button when filters are active', () => {
+    render(
+      <FilterPresets
+        presets={mockPresets}
+        currentFilters={{ status: 'active' }}
+        onApplyPreset={vi.fn()}
+        onSavePreset={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Save as preset')).toBeInTheDocument()
+  })
+
+  it('should not show "Save as preset" button when no active filters', () => {
+    render(
+      <FilterPresets
+        presets={mockPresets}
+        currentFilters={{}}
+        onApplyPreset={vi.fn()}
+        onSavePreset={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByText('Save as preset')).not.toBeInTheDocument()
+  })
+
+  it('should not show "Save as preset" when showSave is false', () => {
+    render(
+      <FilterPresets
+        presets={mockPresets}
+        currentFilters={{ status: 'active' }}
+        onApplyPreset={vi.fn()}
+        onSavePreset={vi.fn()}
+        showSave={false}
+      />
+    )
+
+    expect(screen.queryByText('Save as preset')).not.toBeInTheDocument()
+  })
+
+  it('should open save dialog when "Save as preset" clicked', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <FilterPresets
+        presets={mockPresets}
+        currentFilters={{ status: 'active' }}
+        onApplyPreset={vi.fn()}
+        onSavePreset={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByText('Save as preset'))
+
+    expect(screen.getByText('Save Filter Preset')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('My Filters')).toBeInTheDocument()
+  })
+
+  it('should save preset with name and description', async () => {
+    const onSavePreset = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <FilterPresets
+        presets={mockPresets}
+        currentFilters={{ status: 'active', role: 'admin' }}
+        onApplyPreset={vi.fn()}
+        onSavePreset={onSavePreset}
+      />
+    )
+
+    await user.click(screen.getByText('Save as preset'))
+    await user.type(screen.getByPlaceholderText('My Filters'), 'Custom Preset')
+    await user.type(
+      screen.getByPlaceholderText('Description of this filter preset'),
+      'My description'
+    )
+    await user.click(screen.getByText('Save Preset'))
+
+    expect(onSavePreset).toHaveBeenCalledWith(
+      'Custom Preset',
+      { status: 'active', role: 'admin' },
+      'My description'
+    )
+  })
+
+  it('should save preset without description', async () => {
+    const onSavePreset = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <FilterPresets
+        presets={mockPresets}
+        currentFilters={{ status: 'active' }}
+        onApplyPreset={vi.fn()}
+        onSavePreset={onSavePreset}
+      />
+    )
+
+    await user.click(screen.getByText('Save as preset'))
+    await user.type(screen.getByPlaceholderText('My Filters'), 'No Desc')
+    await user.click(screen.getByText('Save Preset'))
+
+    expect(onSavePreset).toHaveBeenCalledWith('No Desc', { status: 'active' }, undefined)
+  })
+
+  it('should disable save button when name is empty', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <FilterPresets
+        presets={mockPresets}
+        currentFilters={{ status: 'active' }}
+        onApplyPreset={vi.fn()}
+        onSavePreset={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByText('Save as preset'))
+
+    const saveButton = screen.getByText('Save Preset')
+    expect(saveButton).toBeDisabled()
+  })
+
+  it('should close dialog when cancel clicked', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <FilterPresets
+        presets={mockPresets}
+        currentFilters={{ status: 'active' }}
+        onApplyPreset={vi.fn()}
+        onSavePreset={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByText('Save as preset'))
+    expect(screen.getByText('Save Filter Preset')).toBeInTheDocument()
+
+    await user.click(screen.getByText('Cancel'))
+    expect(screen.queryByText('Save Filter Preset')).not.toBeInTheDocument()
+  })
+
+  it('should show delete button for non-default presets', () => {
+    render(
+      <FilterPresets
+        presets={mockPresets}
+        onApplyPreset={vi.fn()}
+        onDeletePreset={vi.fn()}
+      />
+    )
+
+    const deleteButtons = screen.getAllByTitle('Delete preset')
+    expect(deleteButtons).toHaveLength(2) // Not for default preset
+  })
+
+  it('should not show delete button for default preset', () => {
+    render(
+      <FilterPresets
+        presets={[mockPresets[2]]}
+        onApplyPreset={vi.fn()}
+        onDeletePreset={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByTitle('Delete preset')).not.toBeInTheDocument()
+  })
+
+  it('should call onDeletePreset when delete clicked', async () => {
+    const onDeletePreset = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <FilterPresets
+        presets={mockPresets}
+        onApplyPreset={vi.fn()}
+        onDeletePreset={onDeletePreset}
+      />
+    )
+
+    const deleteButtons = screen.getAllByTitle('Delete preset')
+    await user.click(deleteButtons[0])
+
+    expect(onDeletePreset).toHaveBeenCalledWith('1')
+  })
+
+  it('should show update button when filters are active', () => {
+    render(
+      <FilterPresets
+        presets={mockPresets}
+        currentFilters={{ status: 'active' }}
+        onApplyPreset={vi.fn()}
+        onUpdatePreset={vi.fn()}
+      />
+    )
+
+    expect(screen.getAllByTitle('Update preset with current filters')).toHaveLength(3)
+  })
+
+  it('should call onUpdatePreset when update clicked', async () => {
+    const onUpdatePreset = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <FilterPresets
+        presets={mockPresets}
+        currentFilters={{ status: 'inactive' }}
+        onApplyPreset={vi.fn()}
+        onUpdatePreset={onUpdatePreset}
+      />
+    )
+
+    const updateButtons = screen.getAllByTitle('Update preset with current filters')
+    await user.click(updateButtons[0])
+
+    expect(onUpdatePreset).toHaveBeenCalledWith('1', { status: 'inactive' })
+  })
+
+  it('should show "No saved presets" when empty', () => {
+    render(
+      <FilterPresets
+        presets={[]}
+        onApplyPreset={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('No saved presets')).toBeInTheDocument()
+  })
+
+  it('should apply custom className', () => {
+    const { container } = render(
+      <FilterPresets
+        presets={mockPresets}
+        onApplyPreset={vi.fn()}
+        className="custom-class"
+      />
+    )
+
+    expect(container.firstChild).toHaveClass('custom-class')
+  })
+})

--- a/packages/core/src/tables/FilterPresets.tsx
+++ b/packages/core/src/tables/FilterPresets.tsx
@@ -1,0 +1,226 @@
+/**
+ * Filter Presets Component
+ * Allows users to save and load filter combinations
+ */
+
+import { useState } from 'react'
+import type { Filter } from '../types/table'
+
+export interface FilterPreset {
+  id: string
+  name: string
+  filters: Record<string, unknown>
+  description?: string
+  isDefault?: boolean
+}
+
+export interface FilterPresetsProps {
+  /** Available presets */
+  presets: FilterPreset[]
+
+  /** Current active filters */
+  currentFilters?: Record<string, unknown>
+
+  /** Apply preset handler */
+  onApplyPreset: (preset: FilterPreset) => void
+
+  /** Save preset handler */
+  onSavePreset?: (name: string, filters: Record<string, unknown>, description?: string) => void
+
+  /** Delete preset handler */
+  onDeletePreset?: (presetId: string) => void
+
+  /** Update preset handler */
+  onUpdatePreset?: (presetId: string, filters: Record<string, unknown>) => void
+
+  /** Custom className */
+  className?: string
+
+  /** Show save button */
+  showSave?: boolean
+
+  /** Show delete button */
+  showDelete?: boolean
+}
+
+/**
+ * Filter Presets Component
+ * Manage and apply filter presets
+ */
+export function FilterPresets({
+  presets,
+  currentFilters = {},
+  onApplyPreset,
+  onSavePreset,
+  onDeletePreset,
+  onUpdatePreset,
+  className = '',
+  showSave = true,
+  showDelete = true,
+}: FilterPresetsProps) {
+  const [showSaveDialog, setShowSaveDialog] = useState(false)
+  const [presetName, setPresetName] = useState('')
+  const [presetDescription, setPresetDescription] = useState('')
+
+  const handleSave = () => {
+    if (!presetName.trim() || !onSavePreset) return
+
+    onSavePreset(presetName.trim(), currentFilters, presetDescription.trim() || undefined)
+    setPresetName('')
+    setPresetDescription('')
+    setShowSaveDialog(false)
+  }
+
+  const handleUpdate = (presetId: string) => {
+    if (!onUpdatePreset) return
+    onUpdatePreset(presetId, currentFilters)
+  }
+
+  const hasActiveFilters = Object.keys(currentFilters).length > 0
+
+  return (
+    <div className={`space-y-2 ${className}`}>
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium text-gray-700">Filter Presets</h3>
+        {showSave && hasActiveFilters && onSavePreset && (
+          <button
+            type="button"
+            onClick={() => setShowSaveDialog(true)}
+            className="text-sm text-blue-600 hover:text-blue-700 font-medium"
+          >
+            Save as preset
+          </button>
+        )}
+      </div>
+
+      {presets.length === 0 ? (
+        <p className="text-sm text-gray-500">No saved presets</p>
+      ) : (
+        <div className="space-y-1">
+          {presets.map((preset) => (
+            <div
+              key={preset.id}
+              className="flex items-center justify-between p-2 rounded hover:bg-gray-50"
+            >
+              <button
+                type="button"
+                onClick={() => onApplyPreset(preset)}
+                className="flex-1 text-left"
+              >
+                <div className="text-sm font-medium text-gray-900">
+                  {preset.name}
+                  {preset.isDefault && (
+                    <span className="ml-2 text-xs text-gray-500">(Default)</span>
+                  )}
+                </div>
+                {preset.description && (
+                  <div className="text-xs text-gray-500">{preset.description}</div>
+                )}
+              </button>
+
+              <div className="flex items-center gap-1">
+                {onUpdatePreset && hasActiveFilters && (
+                  <button
+                    type="button"
+                    onClick={() => handleUpdate(preset.id)}
+                    className="p-1 text-gray-400 hover:text-gray-600"
+                    title="Update preset with current filters"
+                  >
+                    <svg
+                      className="h-4 w-4"
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                    >
+                      <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+                    </svg>
+                  </button>
+                )}
+                {showDelete && onDeletePreset && !preset.isDefault && (
+                  <button
+                    type="button"
+                    onClick={() => onDeletePreset(preset.id)}
+                    className="p-1 text-gray-400 hover:text-red-600"
+                    title="Delete preset"
+                  >
+                    <svg
+                      className="h-4 w-4"
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {showSaveDialog && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg p-6 w-full max-w-md">
+            <h3 className="text-lg font-medium mb-4">Save Filter Preset</h3>
+
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Preset Name
+                </label>
+                <input
+                  type="text"
+                  value={presetName}
+                  onChange={(e) => setPresetName(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  placeholder="My Filters"
+                  autoFocus
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Description (optional)
+                </label>
+                <textarea
+                  value={presetDescription}
+                  onChange={(e) => setPresetDescription(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  placeholder="Description of this filter preset"
+                  rows={3}
+                />
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-2 mt-6">
+              <button
+                type="button"
+                onClick={() => {
+                  setShowSaveDialog(false)
+                  setPresetName('')
+                  setPresetDescription('')
+                }}
+                className="px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded-md"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={!presetName.trim()}
+                className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Save Preset
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Implemented:
- FilterPresets component for managing saved filter combinations
- Save current filters as named preset with optional description
- Apply saved presets to quickly restore filter combinations
- Update existing presets with current filter values
- Delete presets (except default presets)
- Default preset support with isDefault flag
- Save dialog with name and description inputs
- Visual indicators for default presets
- Conditional UI based on active filters
- Support for hiding save/delete buttons

Added 19 comprehensive tests:
- Rendering presets list
- Preset descriptions and default markers
- Apply preset functionality
- Save preset with name and description
- Update preset with current filters
- Delete preset (with default protection)
- Save dialog behavior
- Form validation
- Empty state handling
- Custom className support

All tests passing. Completes Story 4.4 requirement for filter presets/saved filters.