### PR TITLE
Add ChartWidget component with multiple chart types

### DIFF
--- a/packages/core/src/widgets/ChartWidget.test.tsx
+++ b/packages/core/src/widgets/ChartWidget.test.tsx
@@ -1,0 +1,474 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ChartWidget, Chart, type ChartDataPoint } from './ChartWidget'
+
+const mockData: ChartDataPoint[] = [
+  { label: 'Jan', value: 100 },
+  { label: 'Feb', value: 150 },
+  { label: 'Mar', value: 120 },
+  { label: 'Apr', value: 180 },
+]
+
+describe('ChartWidget', () => {
+  describe('Basic Rendering', () => {
+    it('should render bar chart', () => {
+      render(<ChartWidget type="bar" data={mockData} />)
+
+      expect(screen.getByText('Jan')).toBeInTheDocument()
+      expect(screen.getByText('Feb')).toBeInTheDocument()
+    })
+
+    it('should render line chart', () => {
+      render(<ChartWidget type="line" data={mockData} />)
+
+      expect(screen.getByText('Jan')).toBeInTheDocument()
+      expect(screen.getByText('Apr')).toBeInTheDocument()
+    })
+
+    it('should render pie chart', () => {
+      render(<ChartWidget type="pie" data={mockData} />)
+
+      expect(screen.getByText('Jan')).toBeInTheDocument()
+      expect(screen.getByText('100')).toBeInTheDocument()
+    })
+
+    it('should render area chart', () => {
+      render(<ChartWidget type="area" data={mockData} />)
+
+      expect(screen.getByText('Jan')).toBeInTheDocument()
+      expect(screen.getByText('Mar')).toBeInTheDocument()
+    })
+
+    it('should render donut chart', () => {
+      render(<ChartWidget type="donut" data={mockData} />)
+
+      expect(screen.getByText('Jan')).toBeInTheDocument()
+      expect(screen.getByText('100')).toBeInTheDocument()
+    })
+  })
+
+  describe('Chart Configuration', () => {
+    it('should display title', () => {
+      render(<ChartWidget type="bar" data={mockData} title="Monthly Sales" />)
+
+      expect(screen.getByText('Monthly Sales')).toBeInTheDocument()
+    })
+
+    it('should display description', () => {
+      render(
+        <ChartWidget
+          type="bar"
+          data={mockData}
+          description="Sales data for Q1"
+        />
+      )
+
+      expect(screen.getByText('Sales data for Q1')).toBeInTheDocument()
+    })
+
+    it('should display both title and description', () => {
+      render(
+        <ChartWidget
+          type="bar"
+          data={mockData}
+          title="Monthly Sales"
+          description="Sales data for Q1"
+        />
+      )
+
+      expect(screen.getByText('Monthly Sales')).toBeInTheDocument()
+      expect(screen.getByText('Sales data for Q1')).toBeInTheDocument()
+    })
+
+    it('should apply custom className', () => {
+      const { container } = render(
+        <ChartWidget type="bar" data={mockData} className="custom-chart" />
+      )
+
+      expect(container.querySelector('.custom-chart')).toBeInTheDocument()
+    })
+
+    it('should apply custom height', () => {
+      const { container } = render(
+        <ChartWidget type="bar" data={mockData} height={400} />
+      )
+
+      const chartDiv = container.querySelector('div[style*="height"]')
+      expect(chartDiv).toHaveStyle({ height: '400px' })
+    })
+  })
+
+  describe('Legend', () => {
+    it('should show legend by default for pie chart', () => {
+      render(<ChartWidget type="pie" data={mockData} />)
+
+      mockData.forEach((point) => {
+        expect(screen.getByText(point.label)).toBeInTheDocument()
+        expect(screen.getByText(point.value.toString())).toBeInTheDocument()
+      })
+    })
+
+    it('should hide legend when showLegend is false', () => {
+      render(<ChartWidget type="pie" data={mockData} showLegend={false} />)
+
+      // Labels should not be in legend (but might be in SVG)
+      const labels = screen.queryAllByText('Jan')
+      expect(labels.length).toBeLessThan(2)
+    })
+  })
+
+  describe('Data Labels', () => {
+    it('should show data labels when enabled for bar chart', () => {
+      render(<ChartWidget type="bar" data={mockData} showDataLabels />)
+
+      mockData.forEach((point) => {
+        expect(screen.getByText(point.value.toString())).toBeInTheDocument()
+      })
+    })
+
+    it('should show percentage labels for pie chart', () => {
+      render(<ChartWidget type="pie" data={mockData} showDataLabels />)
+
+      // Should show percentages
+      const svg = document.querySelector('svg')
+      expect(svg).toBeInTheDocument()
+    })
+  })
+
+  describe('Axis Labels', () => {
+    it('should display x-axis label', () => {
+      render(
+        <ChartWidget type="bar" data={mockData} xAxisLabel="Month" />
+      )
+
+      expect(screen.getByText('Month')).toBeInTheDocument()
+    })
+
+    it('should display y-axis label', () => {
+      render(
+        <ChartWidget type="bar" data={mockData} yAxisLabel="Sales ($)" />
+      )
+
+      expect(screen.getByText('Sales ($)')).toBeInTheDocument()
+    })
+
+    it('should display both axis labels', () => {
+      render(
+        <ChartWidget
+          type="line"
+          data={mockData}
+          xAxisLabel="Month"
+          yAxisLabel="Revenue"
+        />
+      )
+
+      expect(screen.getByText('Month')).toBeInTheDocument()
+      expect(screen.getByText('Revenue')).toBeInTheDocument()
+    })
+  })
+
+  describe('Loading State', () => {
+    it('should show loading skeleton', () => {
+      render(<ChartWidget type="bar" data={mockData} loading />)
+
+      const skeleton = document.querySelector('.animate-pulse')
+      expect(skeleton).toBeInTheDocument()
+    })
+
+    it('should show title skeleton when loading', () => {
+      render(
+        <ChartWidget type="bar" data={mockData} title="Sales" loading />
+      )
+
+      const skeleton = document.querySelector('.animate-pulse')
+      expect(skeleton).toBeInTheDocument()
+    })
+  })
+
+  describe('Error State', () => {
+    it('should show error message', () => {
+      render(
+        <ChartWidget
+          type="bar"
+          data={mockData}
+          error="Failed to fetch data"
+        />
+      )
+
+      expect(screen.getByText('Failed to load chart')).toBeInTheDocument()
+      expect(screen.getByText('Failed to fetch data')).toBeInTheDocument()
+    })
+
+    it('should show error icon', () => {
+      render(<ChartWidget type="bar" data={mockData} error="Error" />)
+
+      const svg = screen.getByText('Failed to load chart').parentElement?.querySelector('svg')
+      expect(svg).toBeInTheDocument()
+    })
+  })
+
+  describe('Empty State', () => {
+    it('should show empty message when no data', () => {
+      render(<ChartWidget type="bar" data={[]} />)
+
+      expect(screen.getByText('No data to display')).toBeInTheDocument()
+    })
+  })
+
+  describe('Click Handlers', () => {
+    it('should call onDataPointClick for bar chart', async () => {
+      const handleClick = vi.fn()
+      const user = userEvent.setup()
+
+      render(
+        <ChartWidget
+          type="bar"
+          data={mockData}
+          onDataPointClick={handleClick}
+        />
+      )
+
+      const bars = document.querySelectorAll('rect')
+      if (bars.length > 0) {
+        await user.click(bars[0])
+        expect(handleClick).toHaveBeenCalledWith(mockData[0], 0)
+      }
+    })
+
+    it('should call onDataPointClick for pie chart', async () => {
+      const handleClick = vi.fn()
+      const user = userEvent.setup()
+
+      render(
+        <ChartWidget
+          type="pie"
+          data={mockData}
+          onDataPointClick={handleClick}
+        />
+      )
+
+      const paths = document.querySelectorAll('path')
+      if (paths.length > 0) {
+        await user.click(paths[0])
+        expect(handleClick).toHaveBeenCalled()
+      }
+    })
+
+    it('should call onDataPointClick from legend', async () => {
+      const handleClick = vi.fn()
+      const user = userEvent.setup()
+
+      render(
+        <ChartWidget
+          type="pie"
+          data={mockData}
+          onDataPointClick={handleClick}
+        />
+      )
+
+      const legendItem = screen.getByText('Jan')
+      await user.click(legendItem)
+      expect(handleClick).toHaveBeenCalled()
+    })
+  })
+
+  describe('Custom Colors', () => {
+    it('should apply custom colors', () => {
+      const colors = ['#ff0000', '#00ff00', '#0000ff']
+      render(<ChartWidget type="bar" data={mockData} colors={colors} />)
+
+      const rects = document.querySelectorAll('rect')
+      expect(rects.length).toBeGreaterThan(0)
+    })
+
+    it('should cycle through colors when more data than colors', () => {
+      const colors = ['#ff0000', '#00ff00']
+      const manyDataPoints = [
+        { label: 'A', value: 10 },
+        { label: 'B', value: 20 },
+        { label: 'C', value: 30 },
+        { label: 'D', value: 40 },
+      ]
+      render(<ChartWidget type="bar" data={manyDataPoints} colors={colors} />)
+
+      const rects = document.querySelectorAll('rect')
+      expect(rects.length).toBe(4)
+    })
+
+    it('should use data point color if provided', () => {
+      const dataWithColors: ChartDataPoint[] = [
+        { label: 'A', value: 10, color: '#123456' },
+        { label: 'B', value: 20, color: '#654321' },
+      ]
+      render(<ChartWidget type="bar" data={dataWithColors} />)
+
+      const rects = document.querySelectorAll('rect')
+      expect(rects.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('Grid Lines', () => {
+    it('should show grid lines by default', () => {
+      render(<ChartWidget type="bar" data={mockData} />)
+
+      const lines = document.querySelectorAll('line')
+      expect(lines.length).toBeGreaterThan(0)
+    })
+
+    it('should hide grid lines when showGrid is false', () => {
+      render(<ChartWidget type="bar" data={mockData} showGrid={false} />)
+
+      // Should still have axis lines but not grid lines
+      const lines = document.querySelectorAll('line')
+      expect(lines.length).toBe(2) // Only x and y axis
+    })
+  })
+})
+
+describe('ChartWidgetBuilder', () => {
+  describe('Line Chart Builder', () => {
+    it('should create line chart config', () => {
+      const config = Chart.line()
+        .data(mockData)
+        .title('Sales')
+        .build()
+
+      expect(config.type).toBe('line')
+      expect(config.data).toEqual(mockData)
+      expect(config.title).toBe('Sales')
+    })
+
+    it('should chain all configuration methods', () => {
+      const config = Chart.line()
+        .data(mockData)
+        .title('Monthly Revenue')
+        .description('Q1 2024')
+        .height(400)
+        .showLegend(false)
+        .showGrid(true)
+        .showDataLabels(true)
+        .xAxisLabel('Month')
+        .yAxisLabel('Revenue ($)')
+        .colors(['#ff0000'])
+        .className('custom')
+        .build()
+
+      expect(config.type).toBe('line')
+      expect(config.title).toBe('Monthly Revenue')
+      expect(config.description).toBe('Q1 2024')
+      expect(config.height).toBe(400)
+      expect(config.showLegend).toBe(false)
+      expect(config.showGrid).toBe(true)
+      expect(config.showDataLabels).toBe(true)
+      expect(config.xAxisLabel).toBe('Month')
+      expect(config.yAxisLabel).toBe('Revenue ($)')
+      expect(config.colors).toEqual(['#ff0000'])
+      expect(config.className).toBe('custom')
+    })
+  })
+
+  describe('Bar Chart Builder', () => {
+    it('should create bar chart config', () => {
+      const config = Chart.bar()
+        .data(mockData)
+        .title('Sales by Month')
+        .build()
+
+      expect(config.type).toBe('bar')
+      expect(config.data).toEqual(mockData)
+    })
+  })
+
+  describe('Pie Chart Builder', () => {
+    it('should create pie chart config', () => {
+      const config = Chart.pie()
+        .data(mockData)
+        .title('Market Share')
+        .build()
+
+      expect(config.type).toBe('pie')
+      expect(config.showLegend).toBeUndefined()
+    })
+  })
+
+  describe('Area Chart Builder', () => {
+    it('should create area chart config', () => {
+      const config = Chart.area()
+        .data(mockData)
+        .title('Cumulative Sales')
+        .build()
+
+      expect(config.type).toBe('area')
+    })
+  })
+
+  describe('Donut Chart Builder', () => {
+    it('should create donut chart config', () => {
+      const config = Chart.donut()
+        .data(mockData)
+        .title('Distribution')
+        .build()
+
+      expect(config.type).toBe('donut')
+    })
+  })
+
+  describe('Builder Validation', () => {
+    it('should throw error if data is missing', () => {
+      expect(() => {
+        Chart.line().build()
+      }).toThrow('Chart data is required')
+    })
+
+    it('should throw error if data is empty', () => {
+      expect(() => {
+        Chart.line().data([]).build()
+      }).toThrow('Chart data is required')
+    })
+  })
+
+  describe('Loading and Error States', () => {
+    it('should set loading state', () => {
+      const config = Chart.bar()
+        .data(mockData)
+        .loading(true)
+        .build()
+
+      expect(config.loading).toBe(true)
+    })
+
+    it('should set error message', () => {
+      const config = Chart.bar()
+        .data(mockData)
+        .error('Network error')
+        .build()
+
+      expect(config.error).toBe('Network error')
+    })
+  })
+
+  describe('Click Handler', () => {
+    it('should set click handler', () => {
+      const handler = vi.fn()
+      const config = Chart.bar()
+        .data(mockData)
+        .onDataPointClick(handler)
+        .build()
+
+      expect(config.onDataPointClick).toBe(handler)
+    })
+  })
+
+  describe('Categories', () => {
+    it('should set categories', () => {
+      const categories = ['Q1', 'Q2', 'Q3', 'Q4']
+      const config = Chart.bar()
+        .data(mockData)
+        .categories(categories)
+        .build()
+
+      expect(config.categories).toEqual(categories)
+    })
+  })
+})

--- a/packages/core/src/widgets/ChartWidget.tsx
+++ b/packages/core/src/widgets/ChartWidget.tsx
@@ -1,0 +1,671 @@
+/**
+ * Chart Widget Component
+ * Displays data visualizations with various chart types
+ */
+
+import { useMemo, ReactNode } from 'react'
+
+export type ChartType = 'line' | 'bar' | 'pie' | 'area' | 'donut'
+
+export interface ChartDataPoint {
+  label: string
+  value: number
+  color?: string
+  [key: string]: any
+}
+
+export interface ChartSeries {
+  name: string
+  data: number[]
+  color?: string
+}
+
+export interface ChartWidgetProps {
+  /** Chart type */
+  type: ChartType
+
+  /** Chart data */
+  data: ChartDataPoint[] | ChartSeries[]
+
+  /** Chart title */
+  title?: string
+
+  /** Chart description */
+  description?: string
+
+  /** Chart height in pixels */
+  height?: number
+
+  /** Show legend */
+  showLegend?: boolean
+
+  /** Show grid lines */
+  showGrid?: boolean
+
+  /** Show data labels */
+  showDataLabels?: boolean
+
+  /** X-axis label */
+  xAxisLabel?: string
+
+  /** Y-axis label */
+  yAxisLabel?: string
+
+  /** X-axis categories (for bar/line charts) */
+  categories?: string[]
+
+  /** Custom colors */
+  colors?: string[]
+
+  /** Loading state */
+  loading?: boolean
+
+  /** Error message */
+  error?: string
+
+  /** Custom className */
+  className?: string
+
+  /** Click handler for data points */
+  onDataPointClick?: (dataPoint: ChartDataPoint, index: number) => void
+}
+
+const DEFAULT_COLORS = [
+  '#3b82f6', // blue-500
+  '#10b981', // green-500
+  '#f59e0b', // amber-500
+  '#ef4444', // red-500
+  '#8b5cf6', // purple-500
+  '#ec4899', // pink-500
+  '#06b6d4', // cyan-500
+  '#f97316', // orange-500
+]
+
+/**
+ * Chart Widget Component
+ * Simple data visualization component
+ */
+export function ChartWidget({
+  type,
+  data,
+  title,
+  description,
+  height = 300,
+  showLegend = true,
+  showGrid = true,
+  showDataLabels = false,
+  xAxisLabel,
+  yAxisLabel,
+  categories,
+  colors = DEFAULT_COLORS,
+  loading = false,
+  error,
+  className = '',
+  onDataPointClick,
+}: ChartWidgetProps) {
+  // Normalize data to ChartDataPoint[]
+  const chartData = useMemo(() => {
+    if (data.length === 0) return []
+
+    // Check if it's series data
+    if ('name' in data[0] && 'data' in data[0]) {
+      const series = data as ChartSeries[]
+      return series[0].data.map((value, index) => ({
+        label: categories?.[index] || `Point ${index + 1}`,
+        value,
+        color: colors[index % colors.length],
+      }))
+    }
+
+    return data as ChartDataPoint[]
+  }, [data, categories, colors])
+
+  // Calculate totals for percentage calculations
+  const total = useMemo(() => {
+    return chartData.reduce((sum, point) => sum + point.value, 0)
+  }, [chartData])
+
+  // Render loading state
+  if (loading) {
+    return (
+      <div
+        className={`bg-white rounded-lg shadow p-6 ${className}`}
+        style={{ height }}
+      >
+        <div className="animate-pulse space-y-4">
+          {title && <div className="h-6 bg-gray-200 rounded w-1/3" />}
+          <div className="h-full bg-gray-200 rounded" />
+        </div>
+      </div>
+    )
+  }
+
+  // Render error state
+  if (error) {
+    return (
+      <div
+        className={`bg-white rounded-lg shadow p-6 ${className}`}
+        style={{ height }}
+      >
+        <div className="flex items-center justify-center h-full">
+          <div className="text-center">
+            <div className="text-red-500 mb-2">
+              <svg
+                className="w-12 h-12 mx-auto"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+            </div>
+            <p className="text-gray-900 font-medium">Failed to load chart</p>
+            <p className="text-sm text-gray-500 mt-1">{error}</p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // Render empty state
+  if (chartData.length === 0) {
+    return (
+      <div
+        className={`bg-white rounded-lg shadow p-6 ${className}`}
+        style={{ height }}
+      >
+        <div className="flex items-center justify-center h-full">
+          <p className="text-gray-500">No data to display</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className={`bg-white rounded-lg shadow p-6 ${className}`}>
+      {/* Header */}
+      {(title || description) && (
+        <div className="mb-4">
+          {title && <h3 className="text-lg font-semibold text-gray-900">{title}</h3>}
+          {description && <p className="text-sm text-gray-500 mt-1">{description}</p>}
+        </div>
+      )}
+
+      {/* Chart Container */}
+      <div style={{ height }}>
+        {type === 'pie' || type === 'donut' ? (
+          <PieChart
+            data={chartData}
+            colors={colors}
+            showLegend={showLegend}
+            showDataLabels={showDataLabels}
+            isDonut={type === 'donut'}
+            total={total}
+            onDataPointClick={onDataPointClick}
+          />
+        ) : (
+          <BarLineChart
+            type={type}
+            data={chartData}
+            colors={colors}
+            showGrid={showGrid}
+            showDataLabels={showDataLabels}
+            xAxisLabel={xAxisLabel}
+            yAxisLabel={yAxisLabel}
+            onDataPointClick={onDataPointClick}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+// Simple Pie/Donut Chart Implementation
+function PieChart({
+  data,
+  colors,
+  showLegend,
+  showDataLabels,
+  isDonut,
+  total,
+  onDataPointClick,
+}: {
+  data: ChartDataPoint[]
+  colors: string[]
+  showLegend: boolean
+  showDataLabels: boolean
+  isDonut: boolean
+  total: number
+  onDataPointClick?: (dataPoint: ChartDataPoint, index: number) => void
+}) {
+  const radius = 100
+  const centerX = 120
+  const centerY = 120
+  const innerRadius = isDonut ? radius * 0.6 : 0
+
+  let currentAngle = -90
+
+  const slices = data.map((point, index) => {
+    const percentage = (point.value / total) * 100
+    const angle = (point.value / total) * 360
+    const startAngle = currentAngle
+    const endAngle = currentAngle + angle
+
+    // Convert to radians
+    const startRad = (startAngle * Math.PI) / 180
+    const endRad = (endAngle * Math.PI) / 180
+
+    // Calculate arc path
+    const x1 = centerX + radius * Math.cos(startRad)
+    const y1 = centerY + radius * Math.sin(startRad)
+    const x2 = centerX + radius * Math.cos(endRad)
+    const y2 = centerY + radius * Math.sin(endRad)
+
+    const largeArc = angle > 180 ? 1 : 0
+
+    let path: string
+    if (innerRadius > 0) {
+      // Donut chart
+      const x3 = centerX + innerRadius * Math.cos(endRad)
+      const y3 = centerY + innerRadius * Math.sin(endRad)
+      const x4 = centerX + innerRadius * Math.cos(startRad)
+      const y4 = centerY + innerRadius * Math.sin(startRad)
+
+      path = `M ${x1} ${y1} A ${radius} ${radius} 0 ${largeArc} 1 ${x2} ${y2} L ${x3} ${y3} A ${innerRadius} ${innerRadius} 0 ${largeArc} 0 ${x4} ${y4} Z`
+    } else {
+      // Pie chart
+      path = `M ${centerX} ${centerY} L ${x1} ${y1} A ${radius} ${radius} 0 ${largeArc} 1 ${x2} ${y2} Z`
+    }
+
+    // Label position
+    const labelAngle = startAngle + angle / 2
+    const labelRad = (labelAngle * Math.PI) / 180
+    const labelRadius = innerRadius > 0 ? (radius + innerRadius) / 2 : (radius * 2) / 3
+    const labelX = centerX + labelRadius * Math.cos(labelRad)
+    const labelY = centerY + labelRadius * Math.sin(labelRad)
+
+    currentAngle = endAngle
+
+    return {
+      path,
+      color: point.color || colors[index % colors.length],
+      label: point.label,
+      value: point.value,
+      percentage,
+      labelX,
+      labelY,
+      dataPoint: point,
+    }
+  })
+
+  return (
+    <div className="flex items-center gap-8">
+      <svg width="240" height="240" viewBox="0 0 240 240" className="flex-shrink-0">
+        {slices.map((slice, index) => (
+          <g key={index}>
+            <path
+              d={slice.path}
+              fill={slice.color}
+              stroke="white"
+              strokeWidth="2"
+              className="transition-opacity hover:opacity-80 cursor-pointer"
+              onClick={() => onDataPointClick?.(slice.dataPoint, index)}
+            />
+            {showDataLabels && slice.percentage > 5 && (
+              <text
+                x={slice.labelX}
+                y={slice.labelY}
+                textAnchor="middle"
+                dominantBaseline="middle"
+                className="text-xs font-medium fill-white pointer-events-none"
+              >
+                {slice.percentage.toFixed(0)}%
+              </text>
+            )}
+          </g>
+        ))}
+      </svg>
+
+      {showLegend && (
+        <div className="flex-1 space-y-2">
+          {slices.map((slice, index) => (
+            <div
+              key={index}
+              className="flex items-center gap-2 text-sm cursor-pointer hover:opacity-80"
+              onClick={() => onDataPointClick?.(slice.dataPoint, index)}
+            >
+              <div
+                className="w-3 h-3 rounded-full flex-shrink-0"
+                style={{ backgroundColor: slice.color }}
+              />
+              <span className="text-gray-700 flex-1">{slice.label}</span>
+              <span className="text-gray-900 font-medium">
+                {slice.value.toLocaleString()}
+              </span>
+              <span className="text-gray-500 text-xs">
+                ({slice.percentage.toFixed(1)}%)
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// Simple Bar/Line/Area Chart Implementation
+function BarLineChart({
+  type,
+  data,
+  colors,
+  showGrid,
+  showDataLabels,
+  xAxisLabel,
+  yAxisLabel,
+  onDataPointClick,
+}: {
+  type: ChartType
+  data: ChartDataPoint[]
+  colors: string[]
+  showGrid: boolean
+  showDataLabels: boolean
+  xAxisLabel?: string
+  yAxisLabel?: string
+  onDataPointClick?: (dataPoint: ChartDataPoint, index: number) => void
+}) {
+  const maxValue = Math.max(...data.map((d) => d.value))
+  const chartHeight = 200
+  const chartWidth = 400
+  const padding = 40
+  const barWidth = (chartWidth - padding * 2) / data.length - 10
+
+  return (
+    <div className="flex flex-col items-center">
+      <svg
+        width={chartWidth + padding * 2}
+        height={chartHeight + padding * 2}
+        className="overflow-visible"
+      >
+        {/* Grid lines */}
+        {showGrid && (
+          <g>
+            {[0, 0.25, 0.5, 0.75, 1].map((ratio, index) => (
+              <line
+                key={index}
+                x1={padding}
+                y1={padding + chartHeight * ratio}
+                x2={chartWidth + padding}
+                y2={padding + chartHeight * ratio}
+                stroke="#e5e7eb"
+                strokeWidth="1"
+              />
+            ))}
+          </g>
+        )}
+
+        {/* Y-axis */}
+        <line
+          x1={padding}
+          y1={padding}
+          x2={padding}
+          y2={chartHeight + padding}
+          stroke="#9ca3af"
+          strokeWidth="2"
+        />
+
+        {/* X-axis */}
+        <line
+          x1={padding}
+          y1={chartHeight + padding}
+          x2={chartWidth + padding}
+          y2={chartHeight + padding}
+          stroke="#9ca3af"
+          strokeWidth="2"
+        />
+
+        {/* Bars/Lines */}
+        {type === 'bar' ? (
+          <g>
+            {data.map((point, index) => {
+              const height = (point.value / maxValue) * chartHeight
+              const x = padding + index * (barWidth + 10) + 5
+              const y = padding + chartHeight - height
+
+              return (
+                <g key={index}>
+                  <rect
+                    x={x}
+                    y={y}
+                    width={barWidth}
+                    height={height}
+                    fill={point.color || colors[index % colors.length]}
+                    className="transition-opacity hover:opacity-80 cursor-pointer"
+                    onClick={() => onDataPointClick?.(point, index)}
+                  />
+                  {showDataLabels && (
+                    <text
+                      x={x + barWidth / 2}
+                      y={y - 5}
+                      textAnchor="middle"
+                      className="text-xs fill-gray-600"
+                    >
+                      {point.value}
+                    </text>
+                  )}
+                </g>
+              )
+            })}
+          </g>
+        ) : (
+          <g>
+            {/* Line/Area path */}
+            {(() => {
+              const points = data.map((point, index) => {
+                const x =
+                  padding + (index / (data.length - 1 || 1)) * chartWidth
+                const y =
+                  padding + chartHeight - (point.value / maxValue) * chartHeight
+                return { x, y }
+              })
+
+              const linePath = points
+                .map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`)
+                .join(' ')
+
+              const areaPath =
+                type === 'area'
+                  ? `${linePath} L ${points[points.length - 1].x} ${chartHeight + padding} L ${padding} ${chartHeight + padding} Z`
+                  : null
+
+              return (
+                <>
+                  {areaPath && (
+                    <path
+                      d={areaPath}
+                      fill={colors[0]}
+                      opacity="0.2"
+                      className="pointer-events-none"
+                    />
+                  )}
+                  <path
+                    d={linePath}
+                    fill="none"
+                    stroke={colors[0]}
+                    strokeWidth="2"
+                    className="pointer-events-none"
+                  />
+                  {points.map((point, index) => (
+                    <circle
+                      key={index}
+                      cx={point.x}
+                      cy={point.y}
+                      r="4"
+                      fill={colors[0]}
+                      className="cursor-pointer hover:r-6 transition-all"
+                      onClick={() => onDataPointClick?.(data[index], index)}
+                    />
+                  ))}
+                </>
+              )
+            })()}
+          </g>
+        )}
+
+        {/* X-axis labels */}
+        <g>
+          {data.map((point, index) => {
+            const x =
+              type === 'bar'
+                ? padding + index * (barWidth + 10) + barWidth / 2 + 5
+                : padding + (index / (data.length - 1 || 1)) * chartWidth
+
+            return (
+              <text
+                key={index}
+                x={x}
+                y={chartHeight + padding + 20}
+                textAnchor="middle"
+                className="text-xs fill-gray-600"
+              >
+                {point.label}
+              </text>
+            )
+          })}
+        </g>
+
+        {/* Axis labels */}
+        {yAxisLabel && (
+          <text
+            x={padding - 30}
+            y={padding + chartHeight / 2}
+            textAnchor="middle"
+            transform={`rotate(-90 ${padding - 30} ${padding + chartHeight / 2})`}
+            className="text-sm fill-gray-700 font-medium"
+          >
+            {yAxisLabel}
+          </text>
+        )}
+        {xAxisLabel && (
+          <text
+            x={padding + chartWidth / 2}
+            y={chartHeight + padding + 50}
+            textAnchor="middle"
+            className="text-sm fill-gray-700 font-medium"
+          >
+            {xAxisLabel}
+          </text>
+        )}
+      </svg>
+    </div>
+  )
+}
+
+/**
+ * Chart Widget Builder
+ */
+export class ChartWidgetBuilder {
+  private config: Partial<ChartWidgetProps> = {}
+
+  constructor(type: ChartType) {
+    this.config.type = type
+    this.config.data = []
+  }
+
+  data(data: ChartDataPoint[] | ChartSeries[]): this {
+    this.config.data = data
+    return this
+  }
+
+  title(title: string): this {
+    this.config.title = title
+    return this
+  }
+
+  description(description: string): this {
+    this.config.description = description
+    return this
+  }
+
+  height(height: number): this {
+    this.config.height = height
+    return this
+  }
+
+  showLegend(show = true): this {
+    this.config.showLegend = show
+    return this
+  }
+
+  showGrid(show = true): this {
+    this.config.showGrid = show
+    return this
+  }
+
+  showDataLabels(show = true): this {
+    this.config.showDataLabels = show
+    return this
+  }
+
+  xAxisLabel(label: string): this {
+    this.config.xAxisLabel = label
+    return this
+  }
+
+  yAxisLabel(label: string): this {
+    this.config.yAxisLabel = label
+    return this
+  }
+
+  categories(categories: string[]): this {
+    this.config.categories = categories
+    return this
+  }
+
+  colors(colors: string[]): this {
+    this.config.colors = colors
+    return this
+  }
+
+  loading(loading = true): this {
+    this.config.loading = loading
+    return this
+  }
+
+  error(error: string): this {
+    this.config.error = error
+    return this
+  }
+
+  className(className: string): this {
+    this.config.className = className
+    return this
+  }
+
+  onDataPointClick(handler: (dataPoint: ChartDataPoint, index: number) => void): this {
+    this.config.onDataPointClick = handler
+    return this
+  }
+
+  build(): ChartWidgetProps {
+    if (!this.config.type) {
+      throw new Error('Chart type is required')
+    }
+    if (!this.config.data || this.config.data.length === 0) {
+      throw new Error('Chart data is required')
+    }
+    return this.config as ChartWidgetProps
+  }
+}
+
+export const Chart = {
+  line: () => new ChartWidgetBuilder('line'),
+  bar: () => new ChartWidgetBuilder('bar'),
+  pie: () => new ChartWidgetBuilder('pie'),
+  area: () => new ChartWidgetBuilder('area'),
+  donut: () => new ChartWidgetBuilder('donut'),
+}

--- a/packages/core/src/widgets/index.ts
+++ b/packages/core/src/widgets/index.ts
@@ -4,3 +4,4 @@
  */
 
 export * from './StatsWidget'
+export * from './ChartWidget'


### PR DESCRIPTION
Implements Chart widget with builder pattern supporting:
- Line, bar, pie, area, and donut charts
- SVG-based rendering (no external dependencies)
- Configurable legend, grid, data labels, axis labels
- Loading and error states with proper UI feedback
- Click handlers for interactive data points
- Custom colors and responsive sizing
- Builder pattern: Chart.line(), Chart.bar(), etc.

All 42 tests passing covering rendering, configuration, states, and builder API.