### PR TITLE
feat: add RichTextEditor and MarkdownEditor field builders

### DIFF
--- a/packages/core/src/forms/MarkdownEditor.test.ts
+++ b/packages/core/src/forms/MarkdownEditor.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect, vi } from 'vitest'
+import { z } from 'zod'
+import { MarkdownEditor, MarkdownToolbars } from './MarkdownEditor'
+
+describe('MarkdownEditor', () => {
+  describe('Basic Configuration', () => {
+    it('should create markdown field', () => {
+      const field = MarkdownEditor.make('content')
+        .label('Content')
+        .build()
+
+      expect(field.type).toBe('markdown')
+      expect(field.name).toBe('content')
+      expect(field.label).toBe('Content')
+    })
+
+    it('should set placeholder', () => {
+      const field = MarkdownEditor.make('content')
+        .placeholder('Enter markdown...')
+        .build()
+
+      expect(field.placeholder).toBe('Enter markdown...')
+    })
+
+    it('should set required', () => {
+      const field = MarkdownEditor.make('content')
+        .required()
+        .build()
+
+      expect(field.required).toBe(true)
+    })
+
+    it('should set helper text', () => {
+      const field = MarkdownEditor.make('content')
+        .helperText('Markdown syntax supported')
+        .build()
+
+      expect(field.helperText).toBe('Markdown syntax supported')
+    })
+
+    it('should set default value', () => {
+      const field = MarkdownEditor.make('content')
+        .default('# Default heading')
+        .build()
+
+      expect(field.default).toBe('# Default heading')
+    })
+
+    it('should set column span', () => {
+      const field = MarkdownEditor.make('content')
+        .columnSpan(12)
+        .build()
+
+      expect(field.columnSpan).toBe(12)
+    })
+
+    it('should set custom className', () => {
+      const field = MarkdownEditor.make('content')
+        .className('custom-markdown')
+        .build()
+
+      expect(field.className).toBe('custom-markdown')
+    })
+  })
+
+  describe('State Configuration', () => {
+    it('should set disabled', () => {
+      const field = MarkdownEditor.make('content')
+        .disabled(true)
+        .build()
+
+      expect(field.disabled).toBe(true)
+    })
+
+    it('should set conditional disabled', () => {
+      const disabledFn = (values: Record<string, unknown>) => values.published === true
+      const field = MarkdownEditor.make('content')
+        .disabled(disabledFn)
+        .build()
+
+      expect(field.disabled).toBe(disabledFn)
+    })
+
+    it('should set readonly', () => {
+      const field = MarkdownEditor.make('content')
+        .readonly(true)
+        .build()
+
+      expect(field.readonly).toBe(true)
+    })
+
+    it('should set conditional readonly', () => {
+      const readonlyFn = (values: Record<string, unknown>) => values.locked === true
+      const field = MarkdownEditor.make('content')
+        .readonly(readonlyFn)
+        .build()
+
+      expect(field.readonly).toBe(readonlyFn)
+    })
+
+    it('should set visible', () => {
+      const field = MarkdownEditor.make('content')
+        .visible(false)
+        .build()
+
+      expect(field.visible).toBe(false)
+    })
+
+    it('should set conditional visible', () => {
+      const visibleFn = (values: Record<string, unknown>) => values.type === 'documentation'
+      const field = MarkdownEditor.make('content')
+        .visible(visibleFn)
+        .build()
+
+      expect(field.visible).toBe(visibleFn)
+    })
+  })
+
+  describe('Validation', () => {
+    it('should set validation schema', () => {
+      const schema = z.string().min(10)
+      const field = MarkdownEditor.make('content')
+        .validate(schema)
+        .build()
+
+      expect(field.validation).toBe(schema)
+    })
+
+    it('should set min length', () => {
+      const field = MarkdownEditor.make('content')
+        .minLength(50)
+        .build()
+
+      expect(field.minLength).toBe(50)
+    })
+
+    it('should set max length', () => {
+      const field = MarkdownEditor.make('content')
+        .maxLength(10000)
+        .build()
+
+      expect(field.maxLength).toBe(10000)
+    })
+  })
+
+  describe('Markdown Specific Configuration', () => {
+    it('should show preview by default', () => {
+      const field = MarkdownEditor.make('content').build()
+
+      expect(field.showPreview).toBe(true)
+    })
+
+    it('should hide preview', () => {
+      const field = MarkdownEditor.make('content')
+        .showPreview(false)
+        .build()
+
+      expect(field.showPreview).toBe(false)
+    })
+
+    it('should set preview mode to side', () => {
+      const field = MarkdownEditor.make('content')
+        .previewMode('side')
+        .build()
+
+      expect(field.previewMode).toBe('side')
+    })
+
+    it('should set preview mode to tab', () => {
+      const field = MarkdownEditor.make('content')
+        .previewMode('tab')
+        .build()
+
+      expect(field.previewMode).toBe('tab')
+    })
+
+    it('should set preview mode to bottom', () => {
+      const field = MarkdownEditor.make('content')
+        .previewMode('bottom')
+        .build()
+
+      expect(field.previewMode).toBe('bottom')
+    })
+
+    it('should set height', () => {
+      const field = MarkdownEditor.make('content')
+        .height(400)
+        .build()
+
+      expect(field.height).toBe(400)
+    })
+
+    it('should set max height', () => {
+      const field = MarkdownEditor.make('content')
+        .maxHeight(600)
+        .build()
+
+      expect(field.maxHeight).toBe(600)
+    })
+
+    it('should enable toolbar by default', () => {
+      const field = MarkdownEditor.make('content').build()
+
+      expect(field.enableToolbar).toBe(true)
+    })
+
+    it('should disable toolbar', () => {
+      const field = MarkdownEditor.make('content')
+        .enableToolbar(false)
+        .build()
+
+      expect(field.enableToolbar).toBe(false)
+    })
+
+    it('should set custom toolbar', () => {
+      const toolbar = ['bold', 'italic', 'link', 'preview']
+      const field = MarkdownEditor.make('content')
+        .toolbar(toolbar)
+        .build()
+
+      expect(field.toolbar).toEqual(toolbar)
+    })
+
+    it('should have default toolbar', () => {
+      const field = MarkdownEditor.make('content').build()
+
+      expect(field.toolbar).toBeDefined()
+      expect(field.toolbar?.length).toBeGreaterThan(0)
+    })
+
+    it('should enable syntax highlighting', () => {
+      const field = MarkdownEditor.make('content')
+        .syntaxHighlighting(true)
+        .build()
+
+      expect(field.syntaxHighlighting).toBe(true)
+    })
+
+    it('should enable line numbers', () => {
+      const field = MarkdownEditor.make('content')
+        .lineNumbers(true)
+        .build()
+
+      expect(field.lineNumbers).toBe(true)
+    })
+
+    it('should enable tables', () => {
+      const field = MarkdownEditor.make('content')
+        .enableTables(true)
+        .build()
+
+      expect(field.enableTables).toBe(true)
+    })
+
+    it('should enable checkboxes', () => {
+      const field = MarkdownEditor.make('content')
+        .enableCheckboxes(true)
+        .build()
+
+      expect(field.enableCheckboxes).toBe(true)
+    })
+
+    it('should enable footnotes', () => {
+      const field = MarkdownEditor.make('content')
+        .enableFootnotes(true)
+        .build()
+
+      expect(field.enableFootnotes).toBe(true)
+    })
+
+    it('should enable emoji', () => {
+      const field = MarkdownEditor.make('content')
+        .enableEmoji(true)
+        .build()
+
+      expect(field.enableEmoji).toBe(true)
+    })
+
+    it('should set image upload handler', () => {
+      const handler = vi.fn().mockResolvedValue('https://example.com/image.jpg')
+      const field = MarkdownEditor.make('content')
+        .onImageUpload(handler)
+        .build()
+
+      expect(field.onImageUpload).toBe(handler)
+    })
+
+    it('should set theme', () => {
+      const field = MarkdownEditor.make('content')
+        .theme('dark')
+        .build()
+
+      expect(field.theme).toBe('dark')
+    })
+  })
+
+  describe('Builder Validation', () => {
+    it('should throw error if name is missing', () => {
+      const builder = MarkdownEditor.make('')
+      expect(() => builder.build()).toThrow('Field name is required')
+    })
+  })
+
+  describe('Chaining', () => {
+    it('should chain all configuration methods', () => {
+      const handler = vi.fn()
+      const field = MarkdownEditor.make('content')
+        .label('Documentation')
+        .placeholder('Write docs...')
+        .required(true)
+        .helperText('Markdown supported')
+        .default('# Getting Started')
+        .columnSpan(12)
+        .className('custom')
+        .disabled(false)
+        .readonly(false)
+        .visible(true)
+        .minLength(10)
+        .maxLength(20000)
+        .showPreview(true)
+        .previewMode('side')
+        .height(500)
+        .maxHeight(800)
+        .enableToolbar(true)
+        .toolbar(['bold', 'italic'])
+        .syntaxHighlighting(true)
+        .lineNumbers(true)
+        .enableTables(true)
+        .enableCheckboxes(true)
+        .enableFootnotes(true)
+        .enableEmoji(true)
+        .onImageUpload(handler)
+        .theme('light')
+        .build()
+
+      expect(field.label).toBe('Documentation')
+      expect(field.showPreview).toBe(true)
+      expect(field.previewMode).toBe('side')
+      expect(field.height).toBe(500)
+      expect(field.syntaxHighlighting).toBe(true)
+    })
+  })
+})
+
+describe('MarkdownToolbars', () => {
+  it('should have minimal toolbar preset', () => {
+    expect(MarkdownToolbars.minimal).toBeDefined()
+    expect(MarkdownToolbars.minimal).toContain('bold')
+    expect(MarkdownToolbars.minimal).toContain('italic')
+    expect(MarkdownToolbars.minimal).toContain('preview')
+  })
+
+  it('should have basic toolbar preset', () => {
+    expect(MarkdownToolbars.basic).toBeDefined()
+    expect(MarkdownToolbars.basic).toContain('bulletList')
+    expect(MarkdownToolbars.basic).toContain('heading')
+  })
+
+  it('should have standard toolbar preset', () => {
+    expect(MarkdownToolbars.standard).toBeDefined()
+    expect(MarkdownToolbars.standard).toContain('code')
+    expect(MarkdownToolbars.standard).toContain('codeBlock')
+    expect(MarkdownToolbars.standard).toContain('checkbox')
+  })
+
+  it('should have full toolbar preset', () => {
+    expect(MarkdownToolbars.full).toBeDefined()
+    expect(MarkdownToolbars.full).toContain('table')
+    expect(MarkdownToolbars.full).toContain('hr')
+  })
+
+  it('should have comment toolbar preset', () => {
+    expect(MarkdownToolbars.comment).toBeDefined()
+    expect(MarkdownToolbars.comment.length).toBeLessThan(MarkdownToolbars.standard.length)
+  })
+
+  it('should have documentation toolbar preset', () => {
+    expect(MarkdownToolbars.documentation).toBeDefined()
+    expect(MarkdownToolbars.documentation).toContain('codeBlock')
+    expect(MarkdownToolbars.documentation).toContain('table')
+  })
+
+  it('should have github toolbar preset', () => {
+    expect(MarkdownToolbars.github).toBeDefined()
+    expect(MarkdownToolbars.github).toContain('strikethrough')
+    expect(MarkdownToolbars.github).toContain('checkbox')
+  })
+
+  it('should work with builder', () => {
+    const field = MarkdownEditor.make('content')
+      .toolbar(MarkdownToolbars.github)
+      .build()
+
+    expect(field.toolbar).toEqual(MarkdownToolbars.github)
+  })
+})

--- a/packages/core/src/forms/MarkdownEditor.tsx
+++ b/packages/core/src/forms/MarkdownEditor.tsx
@@ -1,0 +1,400 @@
+/**
+ * Markdown Editor Field Builder
+ * Builder for markdown editing fields with preview
+ */
+
+import type { z } from 'zod'
+
+export interface MarkdownFieldConfig {
+  type: 'markdown'
+  name: string
+  label?: string
+  placeholder?: string
+  helperText?: string
+  required?: boolean
+  disabled?: boolean | ((values: Record<string, unknown>) => boolean)
+  readonly?: boolean | ((values: Record<string, unknown>) => boolean)
+  visible?: boolean | ((values: Record<string, unknown>) => boolean)
+  default?: string
+  validation?: z.ZodType
+  columnSpan?: number
+  className?: string
+  minLength?: number
+  maxLength?: number
+
+  // Markdown specific
+  showPreview?: boolean
+  previewMode?: 'side' | 'tab' | 'bottom'
+  height?: number
+  maxHeight?: number
+  enableToolbar?: boolean
+  toolbar?: MarkdownToolbarOption[]
+  syntaxHighlighting?: boolean
+  lineNumbers?: boolean
+  enableTables?: boolean
+  enableCheckboxes?: boolean
+  enableFootnotes?: boolean
+  enableEmoji?: boolean
+  onImageUpload?: (file: File) => Promise<string>
+  theme?: 'light' | 'dark'
+}
+
+export type MarkdownToolbarOption =
+  | 'bold'
+  | 'italic'
+  | 'strikethrough'
+  | 'heading'
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'h5'
+  | 'h6'
+  | 'quote'
+  | 'code'
+  | 'codeBlock'
+  | 'link'
+  | 'image'
+  | 'table'
+  | 'bulletList'
+  | 'orderedList'
+  | 'checkbox'
+  | 'hr'
+  | 'preview'
+  | 'fullscreen'
+  | 'help'
+  | '|' // Separator
+
+/**
+ * Markdown Editor Builder
+ */
+export class MarkdownEditorBuilder {
+  private config: Partial<MarkdownFieldConfig> = {
+    type: 'markdown',
+    name: '',
+    showPreview: true,
+    previewMode: 'side',
+    height: 300,
+    enableToolbar: true,
+    toolbar: [
+      'bold',
+      'italic',
+      'strikethrough',
+      '|',
+      'heading',
+      'quote',
+      '|',
+      'code',
+      'codeBlock',
+      '|',
+      'bulletList',
+      'orderedList',
+      'checkbox',
+      '|',
+      'link',
+      'image',
+      '|',
+      'table',
+      'hr',
+      '|',
+      'preview',
+      'fullscreen',
+      '|',
+      'help',
+    ],
+    syntaxHighlighting: true,
+    enableTables: true,
+    enableCheckboxes: true,
+    enableFootnotes: false,
+    enableEmoji: true,
+  }
+
+  constructor(name: string) {
+    this.config.name = name
+  }
+
+  label(label: string): this {
+    this.config.label = label
+    return this
+  }
+
+  placeholder(placeholder: string): this {
+    this.config.placeholder = placeholder
+    return this
+  }
+
+  required(required = true): this {
+    this.config.required = required
+    return this
+  }
+
+  disabled(disabled: boolean | ((values: Record<string, unknown>) => boolean)): this {
+    this.config.disabled = disabled
+    return this
+  }
+
+  readonly(readonly: boolean | ((values: Record<string, unknown>) => boolean)): this {
+    this.config.readonly = readonly
+    return this
+  }
+
+  visible(visible: boolean | ((values: Record<string, unknown>) => boolean)): this {
+    this.config.visible = visible
+    return this
+  }
+
+  helperText(text: string): this {
+    this.config.helperText = text
+    return this
+  }
+
+  default(value: string): this {
+    this.config.default = value
+    return this
+  }
+
+  columnSpan(span: number): this {
+    this.config.columnSpan = span
+    return this
+  }
+
+  validate(schema: z.ZodType): this {
+    this.config.validation = schema
+    return this
+  }
+
+  className(className: string): this {
+    this.config.className = className
+    return this
+  }
+
+  minLength(length: number): this {
+    this.config.minLength = length
+    return this
+  }
+
+  maxLength(length: number): this {
+    this.config.maxLength = length
+    return this
+  }
+
+  showPreview(show = true): this {
+    this.config.showPreview = show
+    return this
+  }
+
+  previewMode(mode: 'side' | 'tab' | 'bottom'): this {
+    this.config.previewMode = mode
+    return this
+  }
+
+  height(height: number): this {
+    this.config.height = height
+    return this
+  }
+
+  maxHeight(height: number): this {
+    this.config.maxHeight = height
+    return this
+  }
+
+  enableToolbar(enable = true): this {
+    this.config.enableToolbar = enable
+    return this
+  }
+
+  toolbar(options: MarkdownToolbarOption[]): this {
+    this.config.toolbar = options
+    return this
+  }
+
+  syntaxHighlighting(enable = true): this {
+    this.config.syntaxHighlighting = enable
+    return this
+  }
+
+  lineNumbers(enable = true): this {
+    this.config.lineNumbers = enable
+    return this
+  }
+
+  enableTables(enable = true): this {
+    this.config.enableTables = enable
+    return this
+  }
+
+  enableCheckboxes(enable = true): this {
+    this.config.enableCheckboxes = enable
+    return this
+  }
+
+  enableFootnotes(enable = true): this {
+    this.config.enableFootnotes = enable
+    return this
+  }
+
+  enableEmoji(enable = true): this {
+    this.config.enableEmoji = enable
+    return this
+  }
+
+  onImageUpload(handler: (file: File) => Promise<string>): this {
+    this.config.onImageUpload = handler
+    return this
+  }
+
+  theme(theme: 'light' | 'dark'): this {
+    this.config.theme = theme
+    return this
+  }
+
+  build(): MarkdownFieldConfig {
+    if (!this.config.name) {
+      throw new Error('Field name is required')
+    }
+    return this.config as MarkdownFieldConfig
+  }
+}
+
+export const MarkdownEditor = {
+  make: (name: string) => new MarkdownEditorBuilder(name),
+}
+
+/**
+ * Preset toolbar configurations
+ */
+export const MarkdownToolbars = {
+  /** Minimal toolbar for simple markdown */
+  minimal: ['bold', 'italic', 'link', '|', 'preview'] as MarkdownToolbarOption[],
+
+  /** Basic toolbar for common markdown */
+  basic: [
+    'bold',
+    'italic',
+    'strikethrough',
+    '|',
+    'heading',
+    'quote',
+    '|',
+    'bulletList',
+    'orderedList',
+    '|',
+    'link',
+    'image',
+    '|',
+    'preview',
+    'help',
+  ] as MarkdownToolbarOption[],
+
+  /** Standard toolbar with code support */
+  standard: [
+    'bold',
+    'italic',
+    'strikethrough',
+    '|',
+    'heading',
+    'quote',
+    '|',
+    'code',
+    'codeBlock',
+    '|',
+    'bulletList',
+    'orderedList',
+    'checkbox',
+    '|',
+    'link',
+    'image',
+    '|',
+    'preview',
+    'fullscreen',
+    '|',
+    'help',
+  ] as MarkdownToolbarOption[],
+
+  /** Full toolbar with all options */
+  full: [
+    'bold',
+    'italic',
+    'strikethrough',
+    '|',
+    'h1',
+    'h2',
+    'h3',
+    '|',
+    'quote',
+    'code',
+    'codeBlock',
+    '|',
+    'bulletList',
+    'orderedList',
+    'checkbox',
+    '|',
+    'link',
+    'image',
+    'table',
+    'hr',
+    '|',
+    'preview',
+    'fullscreen',
+    '|',
+    'help',
+  ] as MarkdownToolbarOption[],
+
+  /** Comment/discussion toolbar */
+  comment: [
+    'bold',
+    'italic',
+    '|',
+    'link',
+    'code',
+    '|',
+    'quote',
+    '|',
+    'preview',
+  ] as MarkdownToolbarOption[],
+
+  /** Documentation toolbar */
+  documentation: [
+    'bold',
+    'italic',
+    '|',
+    'heading',
+    'quote',
+    '|',
+    'code',
+    'codeBlock',
+    '|',
+    'bulletList',
+    'orderedList',
+    '|',
+    'link',
+    'image',
+    'table',
+    '|',
+    'preview',
+    'fullscreen',
+    '|',
+    'help',
+  ] as MarkdownToolbarOption[],
+
+  /** GitHub-style markdown toolbar */
+  github: [
+    'bold',
+    'italic',
+    'strikethrough',
+    '|',
+    'heading',
+    'quote',
+    'code',
+    'codeBlock',
+    '|',
+    'bulletList',
+    'orderedList',
+    'checkbox',
+    '|',
+    'link',
+    'image',
+    '|',
+    'preview',
+  ] as MarkdownToolbarOption[],
+}

--- a/packages/core/src/forms/RichTextEditor.test.ts
+++ b/packages/core/src/forms/RichTextEditor.test.ts
@@ -1,0 +1,338 @@
+import { describe, it, expect, vi } from 'vitest'
+import { z } from 'zod'
+import { RichTextEditor, RichTextToolbars } from './RichTextEditor'
+
+describe('RichTextEditor', () => {
+  describe('Basic Configuration', () => {
+    it('should create rich text field', () => {
+      const field = RichTextEditor.make('content')
+        .label('Content')
+        .build()
+
+      expect(field.type).toBe('richtext')
+      expect(field.name).toBe('content')
+      expect(field.label).toBe('Content')
+    })
+
+    it('should set placeholder', () => {
+      const field = RichTextEditor.make('content')
+        .placeholder('Enter content...')
+        .build()
+
+      expect(field.placeholder).toBe('Enter content...')
+    })
+
+    it('should set required', () => {
+      const field = RichTextEditor.make('content')
+        .required()
+        .build()
+
+      expect(field.required).toBe(true)
+    })
+
+    it('should set helper text', () => {
+      const field = RichTextEditor.make('content')
+        .helperText('Enter your article content')
+        .build()
+
+      expect(field.helperText).toBe('Enter your article content')
+    })
+
+    it('should set default value', () => {
+      const field = RichTextEditor.make('content')
+        .default('<p>Default content</p>')
+        .build()
+
+      expect(field.default).toBe('<p>Default content</p>')
+    })
+
+    it('should set column span', () => {
+      const field = RichTextEditor.make('content')
+        .columnSpan(12)
+        .build()
+
+      expect(field.columnSpan).toBe(12)
+    })
+
+    it('should set custom className', () => {
+      const field = RichTextEditor.make('content')
+        .className('custom-editor')
+        .build()
+
+      expect(field.className).toBe('custom-editor')
+    })
+  })
+
+  describe('State Configuration', () => {
+    it('should set disabled', () => {
+      const field = RichTextEditor.make('content')
+        .disabled(true)
+        .build()
+
+      expect(field.disabled).toBe(true)
+    })
+
+    it('should set conditional disabled', () => {
+      const disabledFn = (values: Record<string, unknown>) => values.published === true
+      const field = RichTextEditor.make('content')
+        .disabled(disabledFn)
+        .build()
+
+      expect(field.disabled).toBe(disabledFn)
+    })
+
+    it('should set readonly', () => {
+      const field = RichTextEditor.make('content')
+        .readonly(true)
+        .build()
+
+      expect(field.readonly).toBe(true)
+    })
+
+    it('should set conditional readonly', () => {
+      const readonlyFn = (values: Record<string, unknown>) => values.locked === true
+      const field = RichTextEditor.make('content')
+        .readonly(readonlyFn)
+        .build()
+
+      expect(field.readonly).toBe(readonlyFn)
+    })
+
+    it('should set visible', () => {
+      const field = RichTextEditor.make('content')
+        .visible(false)
+        .build()
+
+      expect(field.visible).toBe(false)
+    })
+
+    it('should set conditional visible', () => {
+      const visibleFn = (values: Record<string, unknown>) => values.type === 'article'
+      const field = RichTextEditor.make('content')
+        .visible(visibleFn)
+        .build()
+
+      expect(field.visible).toBe(visibleFn)
+    })
+  })
+
+  describe('Validation', () => {
+    it('should set validation schema', () => {
+      const schema = z.string().min(10)
+      const field = RichTextEditor.make('content')
+        .validate(schema)
+        .build()
+
+      expect(field.validation).toBe(schema)
+    })
+
+    it('should set min length', () => {
+      const field = RichTextEditor.make('content')
+        .minLength(100)
+        .build()
+
+      expect(field.minLength).toBe(100)
+    })
+
+    it('should set max length', () => {
+      const field = RichTextEditor.make('content')
+        .maxLength(5000)
+        .build()
+
+      expect(field.maxLength).toBe(5000)
+    })
+  })
+
+  describe('Rich Text Specific Configuration', () => {
+    it('should set custom toolbar', () => {
+      const toolbar = ['bold', 'italic', 'link']
+      const field = RichTextEditor.make('content')
+        .toolbar(toolbar)
+        .build()
+
+      expect(field.toolbar).toEqual(toolbar)
+    })
+
+    it('should have default toolbar', () => {
+      const field = RichTextEditor.make('content').build()
+
+      expect(field.toolbar).toBeDefined()
+      expect(field.toolbar?.length).toBeGreaterThan(0)
+    })
+
+    it('should set height', () => {
+      const field = RichTextEditor.make('content')
+        .height(500)
+        .build()
+
+      expect(field.height).toBe(500)
+    })
+
+    it('should set max height', () => {
+      const field = RichTextEditor.make('content')
+        .maxHeight(800)
+        .build()
+
+      expect(field.maxHeight).toBe(800)
+    })
+
+    it('should set allowed formats', () => {
+      const formats = ['bold', 'italic', 'heading']
+      const field = RichTextEditor.make('content')
+        .allowedFormats(formats)
+        .build()
+
+      expect(field.allowedFormats).toEqual(formats)
+    })
+
+    it('should set image upload handler', () => {
+      const handler = vi.fn().mockResolvedValue('https://example.com/image.jpg')
+      const field = RichTextEditor.make('content')
+        .onImageUpload(handler)
+        .build()
+
+      expect(field.onImageUpload).toBe(handler)
+    })
+
+    it('should enable code blocks', () => {
+      const field = RichTextEditor.make('content')
+        .enableCodeBlocks(true)
+        .build()
+
+      expect(field.enableCodeBlocks).toBe(true)
+    })
+
+    it('should disable code blocks', () => {
+      const field = RichTextEditor.make('content')
+        .enableCodeBlocks(false)
+        .build()
+
+      expect(field.enableCodeBlocks).toBe(false)
+    })
+
+    it('should enable tables', () => {
+      const field = RichTextEditor.make('content')
+        .enableTables(true)
+        .build()
+
+      expect(field.enableTables).toBe(true)
+    })
+
+    it('should enable lists', () => {
+      const field = RichTextEditor.make('content')
+        .enableLists(true)
+        .build()
+
+      expect(field.enableLists).toBe(true)
+    })
+
+    it('should enable links', () => {
+      const field = RichTextEditor.make('content')
+        .enableLinks(true)
+        .build()
+
+      expect(field.enableLinks).toBe(true)
+    })
+
+    it('should enable images', () => {
+      const field = RichTextEditor.make('content')
+        .enableImages(true)
+        .build()
+
+      expect(field.enableImages).toBe(true)
+    })
+
+    it('should set theme', () => {
+      const field = RichTextEditor.make('content')
+        .theme('dark')
+        .build()
+
+      expect(field.theme).toBe('dark')
+    })
+  })
+
+  describe('Builder Validation', () => {
+    it('should throw error if name is missing', () => {
+      const builder = RichTextEditor.make('')
+      expect(() => builder.build()).toThrow('Field name is required')
+    })
+  })
+
+  describe('Chaining', () => {
+    it('should chain all configuration methods', () => {
+      const handler = vi.fn()
+      const field = RichTextEditor.make('content')
+        .label('Article Content')
+        .placeholder('Write your article...')
+        .required(true)
+        .helperText('Rich text content')
+        .default('<p>Start here</p>')
+        .columnSpan(12)
+        .className('custom')
+        .disabled(false)
+        .readonly(false)
+        .visible(true)
+        .minLength(10)
+        .maxLength(10000)
+        .toolbar(['bold', 'italic'])
+        .height(400)
+        .maxHeight(600)
+        .onImageUpload(handler)
+        .enableCodeBlocks(true)
+        .enableTables(true)
+        .enableLists(true)
+        .enableLinks(true)
+        .enableImages(true)
+        .theme('light')
+        .build()
+
+      expect(field.label).toBe('Article Content')
+      expect(field.placeholder).toBe('Write your article...')
+      expect(field.required).toBe(true)
+      expect(field.height).toBe(400)
+      expect(field.theme).toBe('light')
+    })
+  })
+})
+
+describe('RichTextToolbars', () => {
+  it('should have minimal toolbar preset', () => {
+    expect(RichTextToolbars.minimal).toBeDefined()
+    expect(RichTextToolbars.minimal).toContain('bold')
+    expect(RichTextToolbars.minimal).toContain('italic')
+  })
+
+  it('should have basic toolbar preset', () => {
+    expect(RichTextToolbars.basic).toBeDefined()
+    expect(RichTextToolbars.basic).toContain('bulletList')
+  })
+
+  it('should have standard toolbar preset', () => {
+    expect(RichTextToolbars.standard).toBeDefined()
+    expect(RichTextToolbars.standard).toContain('h1')
+    expect(RichTextToolbars.standard).toContain('blockquote')
+  })
+
+  it('should have full toolbar preset', () => {
+    expect(RichTextToolbars.full).toBeDefined()
+    expect(RichTextToolbars.full).toContain('table')
+  })
+
+  it('should have comment toolbar preset', () => {
+    expect(RichTextToolbars.comment).toBeDefined()
+    expect(RichTextToolbars.comment.length).toBeLessThan(RichTextToolbars.standard.length)
+  })
+
+  it('should have documentation toolbar preset', () => {
+    expect(RichTextToolbars.documentation).toBeDefined()
+    expect(RichTextToolbars.documentation).toContain('codeBlock')
+  })
+
+  it('should work with builder', () => {
+    const field = RichTextEditor.make('content')
+      .toolbar(RichTextToolbars.minimal)
+      .build()
+
+    expect(field.toolbar).toEqual(RichTextToolbars.minimal)
+  })
+})

--- a/packages/core/src/forms/RichTextEditor.tsx
+++ b/packages/core/src/forms/RichTextEditor.tsx
@@ -1,0 +1,351 @@
+/**
+ * Rich Text Editor Field Builder
+ * Builder for rich text editing fields with formatting options
+ */
+
+import { ReactNode } from 'react'
+import type { z } from 'zod'
+
+export interface RichTextFieldConfig {
+  type: 'richtext'
+  name: string
+  label?: string
+  placeholder?: string
+  helperText?: string
+  required?: boolean
+  disabled?: boolean | ((values: Record<string, unknown>) => boolean)
+  readonly?: boolean | ((values: Record<string, unknown>) => boolean)
+  visible?: boolean | ((values: Record<string, unknown>) => boolean)
+  default?: string
+  validation?: z.ZodType
+  columnSpan?: number
+  className?: string
+  minLength?: number
+  maxLength?: number
+
+  // Rich text specific
+  toolbar?: RichTextToolbarOption[]
+  height?: number
+  maxHeight?: number
+  allowedFormats?: RichTextFormat[]
+  onImageUpload?: (file: File) => Promise<string>
+  enableCodeBlocks?: boolean
+  enableTables?: boolean
+  enableLists?: boolean
+  enableLinks?: boolean
+  enableImages?: boolean
+  theme?: 'light' | 'dark'
+}
+
+export type RichTextFormat =
+  | 'bold'
+  | 'italic'
+  | 'underline'
+  | 'strike'
+  | 'code'
+  | 'heading'
+  | 'blockquote'
+  | 'codeBlock'
+  | 'bulletList'
+  | 'orderedList'
+  | 'link'
+  | 'image'
+  | 'table'
+  | 'horizontalRule'
+  | 'hardBreak'
+  | 'clear'
+
+export type RichTextToolbarOption =
+  | 'bold'
+  | 'italic'
+  | 'underline'
+  | 'strike'
+  | 'code'
+  | 'heading'
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'blockquote'
+  | 'codeBlock'
+  | 'bulletList'
+  | 'orderedList'
+  | 'link'
+  | 'image'
+  | 'table'
+  | 'hr'
+  | 'clear'
+  | '|' // Separator
+
+/**
+ * Rich Text Editor Builder
+ */
+export class RichTextEditorBuilder {
+  private config: Partial<RichTextFieldConfig> = {
+    type: 'richtext',
+    name: '',
+    toolbar: [
+      'bold',
+      'italic',
+      'underline',
+      '|',
+      'heading',
+      'blockquote',
+      '|',
+      'bulletList',
+      'orderedList',
+      '|',
+      'link',
+      'image',
+      '|',
+      'clear',
+    ],
+    height: 300,
+    enableCodeBlocks: true,
+    enableTables: true,
+    enableLists: true,
+    enableLinks: true,
+    enableImages: true,
+  }
+
+  constructor(name: string) {
+    this.config.name = name
+  }
+
+  label(label: string): this {
+    this.config.label = label
+    return this
+  }
+
+  placeholder(placeholder: string): this {
+    this.config.placeholder = placeholder
+    return this
+  }
+
+  required(required = true): this {
+    this.config.required = required
+    return this
+  }
+
+  disabled(disabled: boolean | ((values: Record<string, unknown>) => boolean)): this {
+    this.config.disabled = disabled
+    return this
+  }
+
+  readonly(readonly: boolean | ((values: Record<string, unknown>) => boolean)): this {
+    this.config.readonly = readonly
+    return this
+  }
+
+  visible(visible: boolean | ((values: Record<string, unknown>) => boolean)): this {
+    this.config.visible = visible
+    return this
+  }
+
+  helperText(text: string): this {
+    this.config.helperText = text
+    return this
+  }
+
+  default(value: string): this {
+    this.config.default = value
+    return this
+  }
+
+  columnSpan(span: number): this {
+    this.config.columnSpan = span
+    return this
+  }
+
+  validate(schema: z.ZodType): this {
+    this.config.validation = schema
+    return this
+  }
+
+  className(className: string): this {
+    this.config.className = className
+    return this
+  }
+
+  minLength(length: number): this {
+    this.config.minLength = length
+    return this
+  }
+
+  maxLength(length: number): this {
+    this.config.maxLength = length
+    return this
+  }
+
+  toolbar(options: RichTextToolbarOption[]): this {
+    this.config.toolbar = options
+    return this
+  }
+
+  height(height: number): this {
+    this.config.height = height
+    return this
+  }
+
+  maxHeight(height: number): this {
+    this.config.maxHeight = height
+    return this
+  }
+
+  allowedFormats(formats: RichTextFormat[]): this {
+    this.config.allowedFormats = formats
+    return this
+  }
+
+  onImageUpload(handler: (file: File) => Promise<string>): this {
+    this.config.onImageUpload = handler
+    return this
+  }
+
+  enableCodeBlocks(enable = true): this {
+    this.config.enableCodeBlocks = enable
+    return this
+  }
+
+  enableTables(enable = true): this {
+    this.config.enableTables = enable
+    return this
+  }
+
+  enableLists(enable = true): this {
+    this.config.enableLists = enable
+    return this
+  }
+
+  enableLinks(enable = true): this {
+    this.config.enableLinks = enable
+    return this
+  }
+
+  enableImages(enable = true): this {
+    this.config.enableImages = enable
+    return this
+  }
+
+  theme(theme: 'light' | 'dark'): this {
+    this.config.theme = theme
+    return this
+  }
+
+  build(): RichTextFieldConfig {
+    if (!this.config.name) {
+      throw new Error('Field name is required')
+    }
+    return this.config as RichTextFieldConfig
+  }
+}
+
+export const RichTextEditor = {
+  make: (name: string) => new RichTextEditorBuilder(name),
+}
+
+/**
+ * Preset toolbar configurations
+ */
+export const RichTextToolbars = {
+  /** Minimal toolbar with basic formatting */
+  minimal: ['bold', 'italic', 'link', '|', 'clear'] as RichTextToolbarOption[],
+
+  /** Basic toolbar with common formatting */
+  basic: [
+    'bold',
+    'italic',
+    'underline',
+    '|',
+    'bulletList',
+    'orderedList',
+    '|',
+    'link',
+    '|',
+    'clear',
+  ] as RichTextToolbarOption[],
+
+  /** Standard toolbar with headings and formatting */
+  standard: [
+    'bold',
+    'italic',
+    'underline',
+    'strike',
+    '|',
+    'h1',
+    'h2',
+    'h3',
+    '|',
+    'bulletList',
+    'orderedList',
+    '|',
+    'link',
+    'image',
+    '|',
+    'blockquote',
+    'codeBlock',
+    '|',
+    'clear',
+  ] as RichTextToolbarOption[],
+
+  /** Full toolbar with all options */
+  full: [
+    'bold',
+    'italic',
+    'underline',
+    'strike',
+    'code',
+    '|',
+    'h1',
+    'h2',
+    'h3',
+    '|',
+    'bulletList',
+    'orderedList',
+    '|',
+    'link',
+    'image',
+    '|',
+    'blockquote',
+    'codeBlock',
+    'table',
+    'hr',
+    '|',
+    'clear',
+  ] as RichTextToolbarOption[],
+
+  /** Comment/discussion toolbar */
+  comment: [
+    'bold',
+    'italic',
+    '|',
+    'link',
+    'code',
+    '|',
+    'blockquote',
+    '|',
+    'clear',
+  ] as RichTextToolbarOption[],
+
+  /** Documentation toolbar */
+  documentation: [
+    'bold',
+    'italic',
+    'code',
+    '|',
+    'h1',
+    'h2',
+    'h3',
+    '|',
+    'bulletList',
+    'orderedList',
+    '|',
+    'link',
+    'image',
+    '|',
+    'blockquote',
+    'codeBlock',
+    'table',
+    '|',
+    'clear',
+  ] as RichTextToolbarOption[],
+}


### PR DESCRIPTION
Implements RichTextEditor and MarkdownEditor field builders to complete Story 3.2 (Advanced Form Fields).

RichTextEditor:
- Toolbar configuration with 6 presets (minimal, basic, standard, full, comment, documentation)
- Height/maxHeight settings
- Enable/disable features: code blocks, tables, lists, links, images
- Image upload handler support
- Theme support (light/dark)
- 38 comprehensive tests

MarkdownEditor:
- Preview modes (side, tab, bottom)
- Toolbar configuration with 7 presets including GitHub-style
- Syntax highlighting and line numbers
- Enable/disable features: tables, checkboxes, footnotes, emoji
- Image upload handler support
- 45 comprehensive tests

Both builders follow the established builder pattern with fluent API design and full TypeScript type safety.